### PR TITLE
Remove single quotes from additional tags in TimescaleDB loader

### DIFF
--- a/cmd/tsbs_load_timescaledb/process.go
+++ b/cmd/tsbs_load_timescaledb/process.go
@@ -31,7 +31,7 @@ func newSyncCSI() *syncCSI {
 var globalSyncCSI = newSyncCSI()
 
 func subsystemTagsToJSON(tags []string) string {
-	json := "'{"
+	json := "{"
 	for i, t := range tags {
 		args := strings.Split(t, "=")
 		if i > 0 {
@@ -39,7 +39,7 @@ func subsystemTagsToJSON(tags []string) string {
 		}
 		json += fmt.Sprintf("\"%s\": \"%s\"", args[0], args[1])
 	}
-	json += "}'"
+	json += "}"
 	return json
 }
 


### PR DESCRIPTION
Originally these quotes were needed when using a bulk INSERT
instead of COPY. However for COPY they break the loader since it
is an invalid token.

Fixes #7.