### PR TITLE
Add non-database TimescaleDB loader test coverage

### DIFF
--- a/cmd/tsbs_load_timescaledb/creator.go
+++ b/cmd/tsbs_load_timescaledb/creator.go
@@ -10,18 +10,18 @@ import (
 )
 
 type dbCreator struct {
+	br      *bufio.Reader
 	tags    string
 	cols    []string
 	connStr string
 }
 
 func (d *dbCreator) Init() {
-	br := loader.GetBufferedReader()
-	d.readDataHeader(br)
+	d.readDataHeader(d.br)
 
 	// Needed to connect to user's database in order to drop/create db-name database
 	re := regexp.MustCompile(`(dbname)=\S*\b`)
-	d.connStr = re.ReplaceAllString(getConnectString(), "")
+	d.connStr = strings.TrimSpace(re.ReplaceAllString(d.connStr, ""))
 }
 
 func (d *dbCreator) readDataHeader(br *bufio.Reader) {

--- a/cmd/tsbs_load_timescaledb/creator_test.go
+++ b/cmd/tsbs_load_timescaledb/creator_test.go
@@ -7,6 +7,39 @@ import (
 	"testing"
 )
 
+func TestDBCreatorInit(t *testing.T) {
+	buf := "\n\n\n"
+	cases := []struct {
+		desc    string
+		connStr string
+		want    string
+	}{
+		{
+			desc:    "no dbname replacement needed",
+			connStr: "host=localhost user=foo",
+			want:    "host=localhost user=foo",
+		},
+		{
+			desc:    "replace once",
+			connStr: "host=localhost dbname=test1 user=foo",
+			want:    "host=localhost  user=foo",
+		},
+		{
+			desc:    "replace more",
+			connStr: "dbname=test2 host=localhost dbname=test1 user=foo dbname=test3",
+			want:    "host=localhost  user=foo",
+		},
+	}
+	for _, c := range cases {
+		br := bufio.NewReader(bytes.NewBufferString(buf))
+		dbc := &dbCreator{br: br, connStr: c.connStr}
+		dbc.Init()
+		if got := dbc.connStr; got != c.want {
+			t.Errorf("%s: incorrect connstr: got %s want %s", c.desc, got, c.want)
+		}
+	}
+}
+
 func TestDBCreatorReadDataHeader(t *testing.T) {
 	cases := []struct {
 		desc         string

--- a/cmd/tsbs_load_timescaledb/main.go
+++ b/cmd/tsbs_load_timescaledb/main.go
@@ -117,7 +117,7 @@ func (b *benchmark) GetProcessor() load.Processor {
 }
 
 func (b *benchmark) GetDBCreator() load.DBCreator {
-	return &dbCreator{}
+	return &dbCreator{br: loader.GetBufferedReader(), connStr: getConnectString()}
 }
 
 func main() {

--- a/cmd/tsbs_load_timescaledb/process_test.go
+++ b/cmd/tsbs_load_timescaledb/process_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+func TestSubsystemTagsToJSON(t *testing.T) {
+	cases := []struct {
+		desc string
+		tags []string
+		want string
+	}{
+		{
+			desc: "empty tag list",
+			tags: []string{},
+			want: "{}",
+		},
+		{
+			desc: "only one tag (no commas needed)",
+			tags: []string{"foo=1"},
+			want: "{\"foo\": \"1\"}",
+		},
+		{
+			desc: "two tags (need comma)",
+			tags: []string{"foo=1", "bar=baz"},
+			want: "{\"foo\": \"1\",\"bar\": \"baz\"}",
+		},
+		{
+			desc: "three tags",
+			tags: []string{"foo=1", "bar=baz", "test=true"},
+			want: "{\"foo\": \"1\",\"bar\": \"baz\",\"test\": \"true\"}",
+		},
+	}
+
+	for _, c := range cases {
+		if got := subsystemTagsToJSON(c.tags); got != c.want {
+			t.Errorf("%s: incorrect ouput: got %s want %s", c.desc, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Further gains in test coverage for TimescaleDB will require a
dummy or mock connection object that can implement the same things
as the real database connector.