### PR TITLE
Refresh the tsbs_generate_data/devops pkg + add tests

### DIFF
--- a/cmd/tsbs_generate_data/devops/common_generate_data.go
+++ b/cmd/tsbs_generate_data/devops/common_generate_data.go
@@ -30,6 +30,9 @@ func (s *commonDevopsSimulator) Finished() bool {
 }
 
 func (s *commonDevopsSimulator) Fields() map[string][][]byte {
+	if len(s.hosts) <= 0 {
+		panic("cannot get fields because no hosts added")
+	}
 	return s.fields(s.hosts[0].SimulatedMeasurements)
 }
 

--- a/cmd/tsbs_generate_data/devops/common_generate_data_test.go
+++ b/cmd/tsbs_generate_data/devops/common_generate_data_test.go
@@ -1,0 +1,232 @@
+package devops
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/common"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestCommonDevopsSimulatorFinished(t *testing.T) {
+	cases := []struct {
+		desc       string
+		madePoints uint64
+		maxPoints  uint64
+		want       bool
+	}{
+		{
+			desc:       "made << max",
+			madePoints: 0,
+			maxPoints:  10,
+			want:       false,
+		},
+		{
+			desc:       "made < max",
+			madePoints: 9,
+			maxPoints:  10,
+			want:       false,
+		},
+		{
+			desc:       "made == max",
+			madePoints: 10,
+			maxPoints:  10,
+			want:       true,
+		},
+		{
+			desc:       "made > max",
+			madePoints: 11,
+			maxPoints:  10,
+			want:       true,
+		},
+		{
+			desc:       "made >> max",
+			madePoints: 100,
+			maxPoints:  10,
+			want:       true,
+		},
+	}
+
+	s := &commonDevopsSimulator{}
+	for _, c := range cases {
+		s.madePoints = c.madePoints
+		s.maxPoints = c.maxPoints
+		if got := s.Finished(); got != c.want {
+			t.Errorf("%s: incorrect result: got %v want %v", c.desc, got, c.want)
+		}
+	}
+}
+
+func TestCommonDevopsSimulatorFields(t *testing.T) {
+	s := &commonDevopsSimulator{}
+	host := Host{}
+	host.SimulatedMeasurements = []common.SimulatedMeasurement{NewCPUMeasurement(time.Now())}
+	s.hosts = append(s.hosts, host)
+	fields := s.Fields()
+	if got := len(fields); got != 1 {
+		t.Errorf("fields length does not equal 1: got %d", got)
+	}
+	if got, ok := fields[string(labelCPU)]; ok {
+		if got2 := len(got); got2 <= 0 {
+			t.Errorf("number of fields is non-positive: got %d", got2)
+		}
+	} else {
+		t.Errorf("CPU was not one of the labels")
+	}
+
+	// Add a host with different measurement. This should not affect the results
+	// because we assume each Host has the same set of simulated measurements.
+	// TODO - Examine whether this assumption should be refined.
+	host = Host{}
+	host.SimulatedMeasurements = []common.SimulatedMeasurement{NewMemMeasurement(time.Now())}
+	s.hosts = append(s.hosts, host)
+	fields = s.Fields()
+	if got := len(fields); got != 1 {
+		t.Errorf("fields length does not equal 1: got %d", got)
+	}
+
+	// Add new measurement, this should change the result.
+	host = s.hosts[0]
+	host.SimulatedMeasurements = append(host.SimulatedMeasurements, NewMemMeasurement(time.Now()))
+	s.hosts[0] = host
+	fields = s.Fields()
+	if got := len(fields); got != 2 {
+		t.Errorf("fields length does not equal 2: got %d", got)
+	}
+
+	// Test panic condition
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("did not panic when should")
+			}
+		}()
+		s.hosts = s.hosts[:0]
+		_ = s.Fields()
+	}()
+}
+
+func bprintf(format string, args ...interface{}) []byte {
+	return []byte(fmt.Sprintf(format, args...))
+}
+
+var prefix = []string{"host", "region", "datacenter", "rack", "os", "arch", "team", "service", "service_version", "service_env"}
+
+func TestCommonDevopsSimulatorPopulatePoint(t *testing.T) {
+	s := &commonDevopsSimulator{}
+	numHosts := uint64(2)
+	for i := uint64(0); i < numHosts; i++ {
+		host := Host{
+			Name:               bprintf("%s%d", prefix[0], i),
+			Region:             bprintf("%s%d", prefix[1], i),
+			Datacenter:         bprintf("%s%d", prefix[2], i),
+			Rack:               bprintf("%s%d", prefix[3], i),
+			OS:                 bprintf("%s%d", prefix[4], i),
+			Arch:               bprintf("%s%d", prefix[5], i),
+			Team:               bprintf("%s%d", prefix[6], i),
+			Service:            bprintf("%s%d", prefix[7], i),
+			ServiceVersion:     bprintf("%s%d", prefix[8], i),
+			ServiceEnvironment: bprintf("%s%d", prefix[9], i),
+		}
+		host.SimulatedMeasurements = []common.SimulatedMeasurement{NewCPUMeasurement(time.Now())}
+		s.hosts = append(s.hosts, host)
+	}
+	s.hostIndex = 0
+	s.epochHosts = numHosts - 1
+	p := serialize.NewPoint()
+
+	use := s.populatePoint(p, 0)
+	if !use {
+		t.Errorf("populatePoint returned false when it should be true")
+	}
+	for i := range prefix {
+		want := prefix[i] + "0"
+		if got := string(p.GetTagValue(MachineTagKeys[i])); got != want {
+			t.Errorf("incorrect tag for idx %d: got %s want %s", i, got, want)
+		}
+	}
+	if got := s.madePoints; got != 1 {
+		t.Errorf("made points is not 1: got %d", got)
+	}
+	if got := s.hostIndex; got != 1 {
+		t.Errorf("host index not incremented to 1: got %d", s.hostIndex)
+	}
+
+	// Second time should not want to write the point
+	use = s.populatePoint(p, 0)
+	if use {
+		t.Errorf("populatePoint returned true when it should be false")
+	}
+	for i := range prefix {
+		want := prefix[i] + "0"
+		if got := string(p.GetTagValue(MachineTagKeys[i])); got != want {
+			t.Errorf("incorrect tag for idx %d: got %s want %s", i, got, want)
+		}
+	}
+	if got := s.madePoints; got != 2 {
+		t.Errorf("made points is not 2: got %d", got)
+	}
+	if got := s.hostIndex; got != 2 {
+		t.Errorf("host index not incremented to 2: got %d", s.hostIndex)
+	}
+}
+
+func TestAdjustNumHostsForEpoch(t *testing.T) {
+	totalHosts := 100
+	cases := []struct {
+		desc           string
+		initHosts      uint64
+		epochs         uint64
+		wantEpochHosts []uint64
+	}{
+		{
+			desc:           "no change",
+			initHosts:      uint64(totalHosts),
+			epochs:         5,
+			wantEpochHosts: []uint64{100, 100, 100, 100, 100},
+		},
+		{
+			desc:           "linear change from 0, non-integer",
+			initHosts:      0,
+			epochs:         9,
+			wantEpochHosts: []uint64{0, 12, 25, 37, 50, 62, 75, 87, 100},
+		},
+		{
+			desc:           "linear change from 0, integer",
+			initHosts:      0,
+			epochs:         5,
+			wantEpochHosts: []uint64{0, 25, 50, 75, 100},
+		},
+		{
+			desc:           "linear change from non-0, non-integer",
+			initHosts:      50,
+			epochs:         5,
+			wantEpochHosts: []uint64{50, 62, 75, 87, 100}, // should be 12.5 per epoch, so alternates rounding down and then up
+		},
+		{
+			desc:           "linear change from non-0, integer",
+			initHosts:      60,
+			epochs:         5,
+			wantEpochHosts: []uint64{60, 70, 80, 90, 100},
+		},
+	}
+
+	for _, c := range cases {
+		s := &commonDevopsSimulator{}
+		for i := 0; i < totalHosts; i++ {
+			s.hosts = append(s.hosts, Host{})
+		}
+		s.initHosts = c.initHosts
+		s.epochHosts = c.initHosts
+		s.epochs = c.epochs
+		s.epoch = 0
+		for i := 0; i < int(c.epochs); i++ {
+			want := c.wantEpochHosts[i]
+			if got := s.epochHosts; got != want {
+				t.Errorf("%s: incorrect number of hosts in epoch %d: got %d want %d", c.desc, i, got, want)
+			}
+			s.adjustNumHostsForEpoch()
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/cpu.go
+++ b/cmd/tsbs_generate_data/devops/cpu.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	labelCPU  = []byte("cpu") // heap optimization
-	CPUFields = []labeledDistributionMaker{
+	cpuFields = []labeledDistributionMaker{
 		{[]byte("usage_user"), func() common.Distribution { return common.CWD(cpuND, 0.0, 100.0, rand.Float64()*100.0) }},
 		{[]byte("usage_system"), func() common.Distribution { return common.CWD(cpuND, 0.0, 100.0, rand.Float64()*100.0) }},
 		{[]byte("usage_idle"), func() common.Distribution { return common.CWD(cpuND, 0.0, 100.0, rand.Float64()*100.0) }},
@@ -34,7 +34,7 @@ type CPUMeasurement struct {
 }
 
 func NewCPUMeasurement(start time.Time) *CPUMeasurement {
-	return newCPUMeasurementNumDistributions(start, len(CPUFields))
+	return newCPUMeasurementNumDistributions(start, len(cpuFields))
 }
 
 func newSingleCPUMeasurement(start time.Time) *CPUMeasurement {
@@ -42,10 +42,10 @@ func newSingleCPUMeasurement(start time.Time) *CPUMeasurement {
 }
 
 func newCPUMeasurementNumDistributions(start time.Time, numDistributions int) *CPUMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, CPUFields[:numDistributions])
+	sub := newSubsystemMeasurementWithDistributionMakers(start, cpuFields[:numDistributions])
 	return &CPUMeasurement{sub}
 }
 
 func (m *CPUMeasurement) ToPoint(p *serialize.Point) {
-	m.toPointAllInt64(p, labelCPU, CPUFields)
+	m.toPointAllInt64(p, labelCPU, cpuFields)
 }

--- a/cmd/tsbs_generate_data/devops/cpu_test.go
+++ b/cmd/tsbs_generate_data/devops/cpu_test.go
@@ -1,0 +1,101 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestCPUMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewCPUMeasurement(now)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	fields := ldmToFieldLabels(cpuFields)
+	for i, ldm := range cpuFields {
+		oldVals[string(ldm.label)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestCPUMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewCPUMeasurement(now)
+	duration := time.Second
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelCPU) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelCPU)
+	}
+
+	for _, ldm := range cpuFields {
+		if got := p.GetFieldValue(ldm.label); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", ldm.label)
+		}
+	}
+}
+
+func TestSingleCPUMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := newSingleCPUMeasurement(now)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	fields := ldmToFieldLabels(cpuFields[:1]) // only the first field in this use case
+	if got := len(m.distributions); got != 1 {
+		t.Errorf("single cpu has more than 1 distribution: got %d", got)
+	}
+	for i, f := range fields {
+		oldVals[string(f)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestSingleCPUMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := newSingleCPUMeasurement(now)
+	duration := time.Second
+	fields := cpuFields[:1] // only the first field in this use case
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelCPU) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelCPU)
+	}
+
+	if got := len(p.FieldKeys()); got != 1 {
+		t.Errorf("point has more than 1 field for single cpu: got %d", got)
+	}
+
+	for _, ldm := range fields {
+		if got := p.GetFieldValue(ldm.label); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", ldm.label)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/disk.go
+++ b/cmd/tsbs_generate_data/devops/disk.go
@@ -10,28 +10,41 @@ import (
 )
 
 const (
-	OneTerabyte = 1 << 40
+	oneTerabyte = 1 << 40
 	inodeSize   = 4096
+	pathFmt     = "/dev/sda%d"
 )
 
 var (
-	labelDisk             = []byte("disk") // heap optimization
-	TotalByteString       = []byte("total")
-	FreeByteString        = []byte("free")
-	UsedByteString        = []byte("used")
-	UsedPercentByteString = []byte("used_percent")
-	INodesTotalByteString = []byte("inodes_total")
-	INodesFreeByteString  = []byte("inodes_free")
-	INodesUsedByteString  = []byte("inodes_used")
+	labelDisk            = []byte("disk") // heap optimization
+	labelDiskTotal       = []byte("total")
+	labelDiskFree        = []byte("free")
+	labelDiskUsed        = []byte("used")
+	labelDiskUsedPercent = []byte("used_percent")
+	labelDiskINodesTotal = []byte("inodes_total")
+	labelDiskINodesFree  = []byte("inodes_free")
+	labelDiskINodesUsed  = []byte("inodes_used")
 
-	DiskTags = [][]byte{
-		[]byte("path"),
-		[]byte("fstype"),
+	labelDiskPath   = []byte("path")
+	labelDiskFSType = []byte("fstype")
+
+	fsExt3            = []byte("ext3")
+	fsExt4            = []byte("ext4")
+	fsBtrfs           = []byte("btrfs")
+	diskFSTypeChoices = [][]byte{
+		fsExt3,
+		fsExt4,
+		fsBtrfs,
 	}
-	DiskFSTypeChoices = [][]byte{
-		[]byte("ext3"),
-		[]byte("ext4"),
-		[]byte("btrfs"),
+
+	diskFields = [][]byte{
+		labelDiskTotal,
+		labelDiskFree,
+		labelDiskUsed,
+		labelDiskUsedPercent,
+		labelDiskINodesTotal,
+		labelDiskINodesFree,
+		labelDiskINodesUsed,
 	}
 )
 
@@ -43,10 +56,10 @@ type DiskMeasurement struct {
 }
 
 func NewDiskMeasurement(start time.Time) *DiskMeasurement {
-	path := []byte(fmt.Sprintf("/dev/sda%d", rand.Intn(10)))
-	fsType := DiskFSTypeChoices[rand.Intn(len(DiskFSTypeChoices))]
+	path := []byte(fmt.Sprintf(pathFmt, rand.Intn(10)))
+	fsType := randomByteStringSliceChoice(diskFSTypeChoices)
 	sub := newSubsystemMeasurement(start, 1)
-	sub.distributions[0] = common.CWD(common.ND(50, 1), 0, OneTerabyte, OneTerabyte/2)
+	sub.distributions[0] = common.CWD(common.ND(50, 1), 0, oneTerabyte, oneTerabyte/2)
 
 	return &DiskMeasurement{
 		subsystemMeasurement: sub,
@@ -59,25 +72,32 @@ func (m *DiskMeasurement) ToPoint(p *serialize.Point) {
 	p.SetMeasurementName(labelDisk)
 	p.SetTimestamp(&m.timestamp)
 
-	p.AppendTag(DiskTags[0], m.path)
-	p.AppendTag(DiskTags[1], m.fsType)
+	p.AppendTag(labelDiskPath, m.path)
+	p.AppendTag(labelDiskFSType, m.fsType)
 
 	// the only thing that actually changes is the free byte count:
 	free := int64(m.distributions[0].Get())
 
-	total := int64(OneTerabyte)
+	total := int64(oneTerabyte)
 	used := total - free
 	usedPercent := int64(100.0 * (float64(used) / float64(total)))
 
+	// TODO Not sure this is strictly accurate, since integer division rounds
+	// down this will give slightly inaccurate results for free & used. Ideally
+	// the free distribution is clamped to the nearest inode size, but that's
+	// a bigger change for another day.
+	//
+	// Previously, dividing all values by inodeSize could give broken semantics
+	// like total != free + used, so at least that is fixed.
 	inodesTotal := total / inodeSize
 	inodesFree := free / inodeSize
-	inodesUsed := used / inodeSize
+	inodesUsed := inodesTotal - inodesFree
 
-	p.AppendField(TotalByteString, total)
-	p.AppendField(FreeByteString, free)
-	p.AppendField(UsedByteString, used)
-	p.AppendField(UsedPercentByteString, usedPercent)
-	p.AppendField(INodesTotalByteString, inodesTotal)
-	p.AppendField(INodesFreeByteString, inodesFree)
-	p.AppendField(INodesUsedByteString, inodesUsed)
+	p.AppendField(diskFields[0], total)
+	p.AppendField(diskFields[1], free)
+	p.AppendField(diskFields[2], used)
+	p.AppendField(diskFields[3], usedPercent)
+	p.AppendField(diskFields[4], inodesTotal)
+	p.AppendField(diskFields[5], inodesFree)
+	p.AppendField(diskFields[6], inodesUsed)
 }

--- a/cmd/tsbs_generate_data/devops/disk_test.go
+++ b/cmd/tsbs_generate_data/devops/disk_test.go
@@ -1,0 +1,96 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestDiskMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewDiskMeasurement(now)
+	origPath := string(m.path)
+	origFS := string(m.fsType)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	fields := [][]byte{[]byte("free")}
+	for i, f := range fields {
+		oldVals[string(f)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := string(m.path); got != origPath {
+		t.Errorf("disk path tag is incorrect: got %s want %s", got, origPath)
+	}
+	if got := string(m.fsType); got != origFS {
+		t.Errorf("disk FS type is incorrect: got %s want %s", got, origFS)
+	}
+
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := string(m.path); got != origPath {
+		t.Errorf("disk path tag is incorrect: got %s want %s", got, origPath)
+	}
+	if got := string(m.fsType); got != origFS {
+		t.Errorf("disk FS type is incorrect: got %s want %s", got, origFS)
+	}
+}
+
+func TestDiskMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewDiskMeasurement(now)
+	origPath := string(m.path)
+	origFS := string(m.fsType)
+	testIfInByteStringSlice(t, diskFSTypeChoices, m.fsType)
+	duration := time.Second
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelDisk) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelDisk)
+	}
+	if got := string(p.GetTagValue(labelDiskPath)); got != origPath {
+		t.Errorf("disk path tag is incorrect: got %s want %s", got, origPath)
+	}
+	if got := string(p.GetTagValue(labelDiskFSType)); got != origFS {
+		t.Errorf("disk FS type is incorrect: got %s want %s", got, origFS)
+	}
+
+	free := int64(m.distributions[0].Get())
+	if got := p.GetFieldValue(labelDiskFree); got != free {
+		t.Errorf("free data out of sync with distribution: got %d want %d", got, free)
+	}
+
+	total := p.GetFieldValue(labelDiskTotal).(int64)
+	if got := p.GetFieldValue(labelDiskTotal).(int64); got != oneTerabyte {
+		t.Errorf("total data is not 1TB: got %d", got)
+	}
+	used := p.GetFieldValue(labelDiskUsed).(int64)
+	if total-used != free {
+		t.Errorf("disk semantics do not make sense: %d - %d != %d", total, used, free)
+	}
+
+	totalInodes := p.GetFieldValue(labelDiskINodesTotal).(int64)
+	usedINodes := p.GetFieldValue(labelDiskINodesUsed).(int64)
+	freeInodes := p.GetFieldValue(labelDiskINodesFree).(int64)
+	if totalInodes-usedINodes != freeInodes {
+		t.Errorf("disk semantics for inodes do not make sense: %d - %d != %d", total, used, free)
+	}
+
+	for _, f := range diskFields {
+		if got := p.GetFieldValue(f); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", f)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/diskio.go
+++ b/cmd/tsbs_generate_data/devops/diskio.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	labelDiskIO      = []byte("diskio") // heap optimization
-	SerialByteString = []byte("serial")
+	labelDiskIO       = []byte("diskio") // heap optimization
+	labelDiskIOSerial = []byte("serial")
 
 	// Reuse NormalDistributions as arguments to other distributions. This is
 	// safe to do because the higher-level distribution advances the ND and
@@ -20,7 +20,7 @@ var (
 	bytesND = common.ND(100, 1)
 	timeND  = common.ND(5, 1)
 
-	DiskIOFields = []labeledDistributionMaker{
+	diskIOFields = []labeledDistributionMaker{
 		{[]byte("reads"), func() common.Distribution { return common.MWD(opsND, 0) }},
 		{[]byte("writes"), func() common.Distribution { return common.MWD(opsND, 0) }},
 		{[]byte("read_bytes"), func() common.Distribution { return common.MWD(bytesND, 0) }},
@@ -37,7 +37,7 @@ type DiskIOMeasurement struct {
 }
 
 func NewDiskIOMeasurement(start time.Time) *DiskIOMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, DiskIOFields)
+	sub := newSubsystemMeasurementWithDistributionMakers(start, diskIOFields)
 	serial := []byte(fmt.Sprintf("%03d-%03d-%03d", rand.Intn(1000), rand.Intn(1000), rand.Intn(1000)))
 	return &DiskIOMeasurement{
 		subsystemMeasurement: sub,
@@ -46,6 +46,6 @@ func NewDiskIOMeasurement(start time.Time) *DiskIOMeasurement {
 }
 
 func (m *DiskIOMeasurement) ToPoint(p *serialize.Point) {
-	m.toPointAllInt64(p, labelDiskIO, DiskIOFields)
-	p.AppendTag(SerialByteString, m.serial)
+	m.toPointAllInt64(p, labelDiskIO, diskIOFields)
+	p.AppendTag(labelDiskIOSerial, m.serial)
 }

--- a/cmd/tsbs_generate_data/devops/diskio_test.go
+++ b/cmd/tsbs_generate_data/devops/diskio_test.go
@@ -1,0 +1,63 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestDiskIOMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewDiskIOMeasurement(now)
+	origSerial := string(m.serial)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	fields := ldmToFieldLabels(diskIOFields)
+	for i, ldm := range diskIOFields {
+		oldVals[string(ldm.label)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := string(m.serial); got != origSerial {
+		t.Errorf("server name updated unexpectedly: got %s want %s", got, origSerial)
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := string(m.serial); got != origSerial {
+		t.Errorf("server name updated unexpectedly: got %s want %s", got, origSerial)
+	}
+}
+
+func TestDiskIOMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewDiskIOMeasurement(now)
+	origSerial := string(m.serial)
+	duration := time.Second
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelDiskIO) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelDiskIO)
+	}
+
+	if got := string(p.GetTagValue(labelDiskIOSerial)); got != origSerial {
+		t.Errorf("incorrect tag value for server name: got %s want %s", got, origSerial)
+	}
+
+	for _, ldm := range diskIOFields {
+		if got := p.GetFieldValue(ldm.label); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", ldm.label)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/kernel.go
+++ b/cmd/tsbs_generate_data/devops/kernel.go
@@ -9,15 +9,15 @@ import (
 )
 
 var (
-	labelKernel        = []byte("kernel") // heap optimization
-	BootTimeByteString = []byte("boot_time")
+	labelKernel         = []byte("kernel") // heap optimization
+	labelKernelBootTime = []byte("boot_time")
 
 	// Reuse NormalDistributions as arguments to other distributions. This is
 	// safe to do because the higher-level distribution advances the ND and
 	// immediately uses its value and saves the state
 	kernelND = common.ND(5, 1)
 
-	KernelFields = []labeledDistributionMaker{
+	kernelFields = []labeledDistributionMaker{
 		{[]byte("interrupts"), func() common.Distribution { return common.MWD(kernelND, 0) }},
 		{[]byte("context_switches"), func() common.Distribution { return common.MWD(kernelND, 0) }},
 		{[]byte("processes_forked"), func() common.Distribution { return common.MWD(kernelND, 0) }},
@@ -32,7 +32,7 @@ type KernelMeasurement struct {
 }
 
 func NewKernelMeasurement(start time.Time) *KernelMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, KernelFields)
+	sub := newSubsystemMeasurementWithDistributionMakers(start, kernelFields)
 	bootTime := rand.Int63n(240)
 	return &KernelMeasurement{
 		subsystemMeasurement: sub,
@@ -41,6 +41,6 @@ func NewKernelMeasurement(start time.Time) *KernelMeasurement {
 }
 
 func (m *KernelMeasurement) ToPoint(p *serialize.Point) {
-	p.AppendField(BootTimeByteString, m.bootTime)
-	m.toPointAllInt64(p, labelKernel, KernelFields)
+	p.AppendField(labelKernelBootTime, m.bootTime)
+	m.toPointAllInt64(p, labelKernel, kernelFields)
 }

--- a/cmd/tsbs_generate_data/devops/kernel_test.go
+++ b/cmd/tsbs_generate_data/devops/kernel_test.go
@@ -1,0 +1,63 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestKernelMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewKernelMeasurement(now)
+	duration := time.Second
+	bootTime := m.bootTime
+	oldVals := map[string]float64{}
+	fields := ldmToFieldLabels(kernelFields)
+	for i, ldm := range kernelFields {
+		oldVals[string(ldm.label)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := m.bootTime; got != bootTime {
+		t.Errorf("boot time changed unexpectedly: got %d", got)
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := m.bootTime; got != bootTime {
+		t.Errorf("boot time changed unexpectedly: got %d", got)
+	}
+}
+
+func TestKernelMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewKernelMeasurement(now)
+	duration := time.Second
+	bootTime := m.bootTime
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelKernel) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelKernel)
+	}
+
+	if got := p.GetFieldValue(labelKernelBootTime).(int64); got != bootTime {
+		t.Errorf("boot time changed unexpectedly: got %d want %d", got, bootTime)
+	}
+
+	for _, ldm := range kernelFields {
+		if got := p.GetFieldValue(ldm.label); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", ldm.label)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/measurement_test.go
+++ b/cmd/tsbs_generate_data/devops/measurement_test.go
@@ -2,6 +2,7 @@ package devops
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -12,6 +13,30 @@ import (
 	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
 )
 
+func ldmToFieldLabels(ldm []labeledDistributionMaker) [][]byte {
+	ret := make([][]byte, 0)
+	for _, l := range ldm {
+		ret = append(ret, l.label)
+	}
+	return ret
+}
+
+// testDistributionsAreDifferent is used to check that the field values for a
+// measurement have changed after a call to Tick.
+func testDistributionsAreDifferent(oldVals map[string]float64, m *subsystemMeasurement, fields [][]byte) error {
+	for i, f := range fields {
+		k := string(f)
+		curr := m.distributions[i].Get()
+		if oldVals[k] == curr {
+			return fmt.Errorf("value for %s unexpectedly the same: got %f", k, curr)
+		}
+		oldVals[k] = curr
+	}
+	return nil
+}
+
+// monotonicDistribution simply increases the state by 1 every time Advance is
+// called. This is a useful distribution for easy testing.
 type monotonicDistribution struct {
 	state float64
 }

--- a/cmd/tsbs_generate_data/devops/mem_test.go
+++ b/cmd/tsbs_generate_data/devops/mem_test.go
@@ -1,0 +1,123 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestMemMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewMemMeasurement(now)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	oldTotal := m.bytesTotal
+	testIfInInt64Slice(t, memoryTotalChoices, oldTotal)
+	fields := [][]byte{[]byte("used"), []byte("cached"), []byte("buffered")}
+	for i, f := range fields {
+		oldVals[string(f)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := m.bytesTotal; got != oldTotal {
+		t.Errorf("total bytes unexpectedly changed: got %d want %d", got, oldTotal)
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := m.bytesTotal; got != oldTotal {
+		t.Errorf("total bytes unexpectedly changed: got %d want %d", got, oldTotal)
+	}
+}
+
+func TestMemMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewMemMeasurement(now)
+	duration := time.Second
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelMem) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelMem)
+	}
+	totalKey := []byte("total")
+	if got := p.GetFieldValue(totalKey); got != m.bytesTotal {
+		t.Errorf("incorrect total: got %d want %d", got, m.bytesTotal)
+	}
+
+	usedKey := []byte("used")
+	cachedKey := []byte("cached")
+	bufferedKey := []byte("buffered")
+	availableKey := []byte("available")
+
+	used := p.GetFieldValue(usedKey).(int64)
+	if used < 0 {
+		t.Errorf("used data semantics incorrect: %d is less than 0", used)
+	}
+	want := int64(m.distributions[0].Get())
+	if got := used; got != want {
+		t.Errorf("used data out of sync with distribution: got %d want %d", got, want)
+	}
+
+	cached := p.GetFieldValue(cachedKey).(int64)
+	if cached < 0 {
+		t.Errorf("cached data semantics incorrect: %d is less than 0", cached)
+	}
+	want = int64(m.distributions[1].Get())
+	if got := cached; got != want {
+		t.Errorf("cached data out of sync with distribution: got %d want %d", got, want)
+	}
+
+	buffered := p.GetFieldValue(bufferedKey).(int64)
+	if buffered < 0 {
+		t.Errorf("buffered data semantics incorrect: %d is less than 0", buffered)
+	}
+	want = int64(m.distributions[2].Get())
+	if got := buffered; got != want {
+		t.Errorf("buffered data out of sync with distribution: got %d want %d", got, want)
+	}
+
+	total := p.GetFieldValue(totalKey).(int64)
+	if total < 0 {
+		t.Errorf("total data semantics incorrect: %d is less than 0", total)
+	}
+	available := p.GetFieldValue(availableKey).(int64)
+	if available < 0 {
+		t.Errorf("available data semantics incorrect: %d is less than 0", available)
+	}
+
+	if total-int64(used) != int64(available) {
+		t.Errorf("memory semantics do not make sense: %d - %d != %d", total, used, available)
+	}
+
+	usedPerc := 100.0 * float64(used) / float64(total)
+	if got := p.GetFieldValue([]byte("used_percent")); got != usedPerc {
+		t.Errorf("memory semantics do not make sense (used perc): got %f want %f", got, usedPerc)
+	}
+
+	availablePerc := 100.0 * float64(available) / float64(total)
+	if got := p.GetFieldValue([]byte("available_percent")); got != availablePerc {
+		t.Errorf("memory semantics do not make sense (available perc): got %f want %f", got, availablePerc)
+	}
+
+	bufferedPerc := 100.0 * float64(buffered) / float64(total)
+	if got := p.GetFieldValue([]byte("buffered_percent")); got != bufferedPerc {
+		t.Errorf("memory semantics do not make sense (buffered perc): got %f want %f", got, bufferedPerc)
+	}
+
+	for _, f := range memoryFieldKeys {
+		if got := p.GetFieldValue(f); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", f)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/net.go
+++ b/cmd/tsbs_generate_data/devops/net.go
@@ -19,7 +19,7 @@ var (
 	highND = common.ND(50, 1)
 	lowND  = common.ND(5, 1)
 
-	NetFields = []labeledDistributionMaker{
+	netFields = []labeledDistributionMaker{
 		{[]byte("bytes_sent"), func() common.Distribution { return common.MWD(highND, 0) }},
 		{[]byte("bytes_recv"), func() common.Distribution { return common.MWD(highND, 0) }},
 		{[]byte("packets_sent"), func() common.Distribution { return common.MWD(highND, 0) }},
@@ -37,7 +37,7 @@ type NetMeasurement struct {
 }
 
 func NewNetMeasurement(start time.Time) *NetMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, NetFields)
+	sub := newSubsystemMeasurementWithDistributionMakers(start, netFields)
 	interfaceName := []byte(fmt.Sprintf("eth%d", rand.Intn(4)))
 	return &NetMeasurement{
 		subsystemMeasurement: sub,
@@ -46,6 +46,6 @@ func NewNetMeasurement(start time.Time) *NetMeasurement {
 }
 
 func (m *NetMeasurement) ToPoint(p *serialize.Point) {
-	m.toPointAllInt64(p, labelNet, NetFields)
+	m.toPointAllInt64(p, labelNet, netFields)
 	p.AppendTag(labelNetTagInterface, m.interfaceName)
 }

--- a/cmd/tsbs_generate_data/devops/net_test.go
+++ b/cmd/tsbs_generate_data/devops/net_test.go
@@ -1,0 +1,63 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestNetMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewNetMeasurement(now)
+	origName := string(m.interfaceName)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	fields := ldmToFieldLabels(netFields)
+	for i, ldm := range netFields {
+		oldVals[string(ldm.label)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := string(m.interfaceName); got != origName {
+		t.Errorf("server name updated unexpectedly: got %s want %s", got, origName)
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if got := string(m.interfaceName); got != origName {
+		t.Errorf("server name updated unexpectedly: got %s want %s", got, origName)
+	}
+}
+
+func TestNetMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewNetMeasurement(now)
+	origName := string(m.interfaceName)
+	duration := time.Second
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelNet) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelNet)
+	}
+
+	if got := string(p.GetTagValue(labelNetTagInterface)); got != origName {
+		t.Errorf("incorrect tag value for server name: got %s want %s", got, origName)
+	}
+
+	for _, ldm := range netFields {
+		if got := p.GetFieldValue(ldm.label); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", ldm.label)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/nginx.go
+++ b/cmd/tsbs_generate_data/devops/nginx.go
@@ -19,7 +19,7 @@ var (
 	// immediately uses its value and saves the state
 	nginxND = common.ND(5, 1)
 
-	NginxFields = []labeledDistributionMaker{
+	nginxFields = []labeledDistributionMaker{
 		{[]byte("accepts"), func() common.Distribution { return common.MWD(nginxND, 0) }},
 		{[]byte("active"), func() common.Distribution { return common.CWD(nginxND, 0, 100, 0) }},
 		{[]byte("handled"), func() common.Distribution { return common.MWD(nginxND, 0) }},
@@ -36,7 +36,7 @@ type NginxMeasurement struct {
 }
 
 func NewNginxMeasurement(start time.Time) *NginxMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, NginxFields)
+	sub := newSubsystemMeasurementWithDistributionMakers(start, nginxFields)
 	serverName := []byte(fmt.Sprintf("nginx_%d", rand.Intn(100000)))
 	port := []byte(fmt.Sprintf("%d", rand.Intn(20000)+1024))
 	return &NginxMeasurement{
@@ -47,7 +47,7 @@ func NewNginxMeasurement(start time.Time) *NginxMeasurement {
 }
 
 func (m *NginxMeasurement) ToPoint(p *serialize.Point) {
-	m.toPointAllInt64(p, labelNginx, NginxFields)
+	m.toPointAllInt64(p, labelNginx, nginxFields)
 	p.AppendTag(labelNginxTagPort, m.port)
 	p.AppendTag(labelNginxTagServer, m.serverName)
 }

--- a/cmd/tsbs_generate_data/devops/postgresql.go
+++ b/cmd/tsbs_generate_data/devops/postgresql.go
@@ -16,7 +16,7 @@ var (
 	pgND     = common.ND(5, 1)
 	pgHighND = common.ND(1024, 1)
 
-	PostgresqlFields = []labeledDistributionMaker{
+	postgresqlFields = []labeledDistributionMaker{
 		{[]byte("numbackends"), func() common.Distribution { return common.CWD(pgND, 0, 1000, 0) }},
 		{[]byte("xact_commit"), func() common.Distribution { return common.CWD(pgND, 0, 1000, 0) }},
 		{[]byte("xact_rollback"), func() common.Distribution { return common.CWD(pgND, 0, 1000, 0) }},
@@ -41,10 +41,10 @@ type PostgresqlMeasurement struct {
 }
 
 func NewPostgresqlMeasurement(start time.Time) *PostgresqlMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, PostgresqlFields)
+	sub := newSubsystemMeasurementWithDistributionMakers(start, postgresqlFields)
 	return &PostgresqlMeasurement{sub}
 }
 
 func (m *PostgresqlMeasurement) ToPoint(p *serialize.Point) {
-	m.toPointAllInt64(p, labelPostgresql, PostgresqlFields)
+	m.toPointAllInt64(p, labelPostgresql, postgresqlFields)
 }

--- a/cmd/tsbs_generate_data/devops/postgresql_test.go
+++ b/cmd/tsbs_generate_data/devops/postgresql_test.go
@@ -1,0 +1,51 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestPostgresqlMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewPostgresqlMeasurement(now)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	fields := ldmToFieldLabels(postgresqlFields)
+	for i, ldm := range postgresqlFields {
+		oldVals[string(ldm.label)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestPostgresqlMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewPostgresqlMeasurement(now)
+	duration := time.Second
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelPostgresql) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelPostgresql)
+	}
+
+	for _, ldm := range postgresqlFields {
+		if got := p.GetFieldValue(ldm.label); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", ldm.label)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/rand.go
+++ b/cmd/tsbs_generate_data/devops/rand.go
@@ -10,7 +10,7 @@ import (
 var (
 	labelRand = []byte("rand") // heap optimization
 
-	RandFields = []labeledDistributionMaker{
+	randFields = []labeledDistributionMaker{
 		{[]byte("usage_user"), func() common.Distribution { return common.UD(0.0, 100.0) }},
 		{[]byte("usage_system"), func() common.Distribution { return common.UD(0.0, 100.0) }},
 		{[]byte("usage_idle"), func() common.Distribution { return common.UD(0.0, 100.0) }},
@@ -29,10 +29,10 @@ type RandMeasurement struct {
 }
 
 func NewRandMeasurement(start time.Time) *RandMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, RandFields)
+	sub := newSubsystemMeasurementWithDistributionMakers(start, randFields)
 	return &RandMeasurement{sub}
 }
 
 func (m *RandMeasurement) ToPoint(p *serialize.Point) {
-	m.toPoint(p, labelRand, RandFields)
+	m.toPoint(p, labelRand, randFields)
 }

--- a/cmd/tsbs_generate_data/devops/rand_test.go
+++ b/cmd/tsbs_generate_data/devops/rand_test.go
@@ -1,0 +1,51 @@
+package devops
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
+)
+
+func TestRandMeasurementTick(t *testing.T) {
+	now := time.Now()
+	m := NewRandMeasurement(now)
+	duration := time.Second
+	oldVals := map[string]float64{}
+	fields := ldmToFieldLabels(randFields)
+	for i, ldm := range randFields {
+		oldVals[string(ldm.label)] = m.distributions[i].Get()
+	}
+
+	rand.Seed(123)
+	m.Tick(duration)
+	err := testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	m.Tick(duration)
+	err = testDistributionsAreDifferent(oldVals, m.subsystemMeasurement, fields)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestRandMeasurementToPoint(t *testing.T) {
+	now := time.Now()
+	m := NewRandMeasurement(now)
+	duration := time.Second
+	m.Tick(duration)
+
+	p := serialize.NewPoint()
+	m.ToPoint(p)
+	if got := string(p.MeasurementName()); got != string(labelRand) {
+		t.Errorf("incorrect measurement name: got %s want %s", got, labelRand)
+	}
+
+	for _, ldm := range randFields {
+		if got := p.GetFieldValue(ldm.label); got == nil {
+			t.Errorf("field %s returned a nil value unexpectedly", ldm.label)
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/devops/redis.go
+++ b/cmd/tsbs_generate_data/devops/redis.go
@@ -23,7 +23,7 @@ var (
 	redisLowND  = common.ND(5, 1)
 	redisHighND = common.ND(50, 1)
 
-	RedisFields = []labeledDistributionMaker{
+	redisFields = []labeledDistributionMaker{
 		{[]byte("total_connections_received"), func() common.Distribution { return common.MWD(redisLowND, 0) }},
 		{[]byte("expired_keys"), func() common.Distribution { return common.MWD(redisHighND, 0) }},
 		{[]byte("evicted_keys"), func() common.Distribution { return common.MWD(redisHighND, 0) }},
@@ -67,7 +67,7 @@ type RedisMeasurement struct {
 }
 
 func NewRedisMeasurement(start time.Time) *RedisMeasurement {
-	sub := newSubsystemMeasurementWithDistributionMakers(start, RedisFields)
+	sub := newSubsystemMeasurementWithDistributionMakers(start, redisFields)
 	serverName := []byte(fmt.Sprintf("redis_%d", rand.Intn(100000)))
 	port := []byte(fmt.Sprintf("%d", rand.Intn(20000)+1024))
 	return &RedisMeasurement{
@@ -85,7 +85,7 @@ func (m *RedisMeasurement) Tick(d time.Duration) {
 
 func (m *RedisMeasurement) ToPoint(p *serialize.Point) {
 	p.AppendField(labelRedisFieldUptime, int64(m.uptime.Seconds()))
-	m.toPointAllInt64(p, labelRedis, RedisFields)
+	m.toPointAllInt64(p, labelRedis, redisFields)
 	p.AppendTag(labelRedisTagPort, m.port)
 	p.AppendTag(labelRedisTagServer, m.serverName)
 }

--- a/cmd/tsbs_generate_data/devops/util.go
+++ b/cmd/tsbs_generate_data/devops/util.go
@@ -1,0 +1,12 @@
+package devops
+
+import "math/rand"
+
+// TODO Replace `randChoice` in host.go with this
+func randomByteStringSliceChoice(s [][]byte) []byte {
+	return s[rand.Intn(len(s))]
+}
+
+func randomInt64SliceChoice(s []int64) int64 {
+	return s[rand.Intn(len(s))]
+}

--- a/cmd/tsbs_generate_data/devops/util_test.go
+++ b/cmd/tsbs_generate_data/devops/util_test.go
@@ -1,0 +1,46 @@
+package devops
+
+import (
+	"bytes"
+	"testing"
+)
+
+func testIfInByteStringSlice(t *testing.T, arr [][]byte, choice []byte) {
+	for _, x := range arr {
+		if bytes.Equal(x, choice) {
+			return
+		}
+	}
+	t.Errorf("could known find choice in array: %s", choice)
+}
+
+func TestRandomByteSliceChoice(t *testing.T) {
+	arr := [][]byte{
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("baz"),
+	}
+	// One million attempts ought to catch it?
+	for i := 0; i < 1000000; i++ {
+		choice := randomByteStringSliceChoice(arr)
+		testIfInByteStringSlice(t, arr, choice)
+	}
+}
+
+func testIfInInt64Slice(t *testing.T, arr []int64, choice int64) {
+	for _, x := range arr {
+		if x == choice {
+			return
+		}
+	}
+	t.Errorf("could known find choice in array: %d", choice)
+}
+
+func TestRandomInt64Choice(t *testing.T) {
+	arr := []int64{0, 10000, 9999}
+	// One million attempts ought to catch it?
+	for i := 0; i < 1000000; i++ {
+		choice := randomInt64SliceChoice(arr)
+		testIfInInt64Slice(t, arr, choice)
+	}
+}


### PR DESCRIPTION
Many unnecessary fields were exported, things that should have
been constants or global (unexported) vars were not, and each
subsystem lacked any testing. Most of these things on a subsystem
basis have been corrected. A few files could use some more de-
exporting of vars and other cleanups.

Additionally, there were some minor sanity-related errors in the
memory and disk subsystems. It was relatively easy for the basic
checks like total = free + used to fail, and some values were put
under the wrong labels in the resulting Points. The simpler ones
were corrected.