### PR TITLE
Update query to increase easy test coverage

### DIFF
--- a/query/stat_processor.go
+++ b/query/stat_processor.go
@@ -99,7 +99,10 @@ func (sp *statProcessor) process(workers uint) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			writeStatGroupMap(os.Stderr, statMapping)
+			err = writeStatGroupMap(os.Stderr, statMapping)
+			if err != nil {
+				log.Fatal(err)
+			}
 			_, err = fmt.Fprintf(os.Stderr, "\n")
 			if err != nil {
 				log.Fatal(err)
@@ -112,7 +115,10 @@ func (sp *statProcessor) process(workers uint) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	writeStatGroupMap(os.Stdout, statMapping)
+	err = writeStatGroupMap(os.Stdout, statMapping)
+	if err != nil {
+		log.Fatal(err)
+	}
 	sp.wg.Done()
 }
 

--- a/query/stat_processor_test.go
+++ b/query/stat_processor_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"testing"
+	"time"
 )
 
 func TestStatProcessorSendStats(t *testing.T) {
@@ -32,6 +33,14 @@ func TestStatProcessorSendStats(t *testing.T) {
 	if r.isWarm {
 		t.Errorf("received stat is warm unexpectedly (2)")
 	}
+
+	// should not send anything
+	wantLen := len(sp.c)
+	sp.sendStats(nil)
+	time.Sleep(25 * time.Millisecond)
+	if got := len(sp.c); got != wantLen {
+		t.Errorf("empty stat array changed channel length: got %d want %d", got, wantLen)
+	}
 }
 
 func TestStatProcessorSendStatsWarm(t *testing.T) {
@@ -58,5 +67,13 @@ func TestStatProcessorSendStatsWarm(t *testing.T) {
 	}
 	if !r.isWarm {
 		t.Errorf("received stat is NOT warm unexpectedly (2)")
+	}
+
+	// should not send anything
+	wantLen := len(sp.c)
+	sp.sendStatsWarm(nil)
+	time.Sleep(25 * time.Millisecond)
+	if got := len(sp.c); got != wantLen {
+		t.Errorf("empty stat array changed channel length: got %d want %d", got, wantLen)
 	}
 }

--- a/query/stats.go
+++ b/query/stats.go
@@ -3,7 +3,6 @@ package query
 import (
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"sort"
 	"sync"
@@ -145,13 +144,13 @@ func (s *statGroup) string() string {
 }
 
 func (s *statGroup) write(w io.Writer) error {
-	_, err := fmt.Fprintf(w, "%s\n", s.string())
+	_, err := fmt.Fprintln(w, s.string())
 	return err
 }
 
 // writeStatGroupMap writes a map of StatGroups in an ordered fashion by
 // key that they are stored by
-func writeStatGroupMap(w io.Writer, statGroups map[string]*statGroup) {
+func writeStatGroupMap(w io.Writer, statGroups map[string]*statGroup) error {
 	maxKeyLength := 0
 	keys := make([]string, 0, len(statGroups))
 	for k := range statGroups {
@@ -163,19 +162,20 @@ func writeStatGroupMap(w io.Writer, statGroups map[string]*statGroup) {
 	sort.Strings(keys)
 	for _, k := range keys {
 		v := statGroups[k]
-		paddedKey := fmt.Sprintf("%s", k)
+		paddedKey := k
 		for len(paddedKey) < maxKeyLength {
 			paddedKey += " "
 		}
 
 		_, err := fmt.Fprintf(w, "%s:\n", paddedKey)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = v.write(w)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 	}
+	return nil
 }

--- a/query/stats_test.go
+++ b/query/stats_test.go
@@ -1,6 +1,12 @@
 package query
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
 
 func TestGetPartialStat(t *testing.T) {
 	s := GetPartialStat()
@@ -200,6 +206,172 @@ func TestStatGroupPush(t *testing.T) {
 		}
 		if got := sg.sum; got != c.wantSum {
 			t.Errorf("%s: incorrect sum: got %f want %f", c.desc, got, c.wantMin)
+		}
+	}
+}
+
+const (
+	errWriterNormal  = "could not write"
+	errWriterSkipOne = "could not write after once"
+)
+
+type errWriter struct {
+	skipOne bool
+	writes  int
+}
+
+func (w *errWriter) Write(p []byte) (int, error) {
+	if w.skipOne {
+		if w.writes > 0 {
+			return 0, fmt.Errorf(errWriterSkipOne)
+		}
+		w.writes++
+		return 0, nil
+	}
+	return 0, fmt.Errorf(errWriterNormal)
+}
+
+func TestWrite(t *testing.T) {
+	var buf bytes.Buffer
+	sg := newStatGroup(0)
+	err := sg.write(&buf)
+	if err != nil {
+		t.Errorf("unexpected error for write: %v", err)
+	}
+	bArr := buf.Bytes()
+	lastCharIdx := len(bArr) - 1
+	if got := string(bArr[lastCharIdx:]); got != "\n" {
+		t.Errorf("did not end write with a newline: got %v", got)
+	}
+
+	// Test error case
+	err = sg.write(&errWriter{})
+	if err == nil {
+		t.Errorf("expected error but did not get one")
+	}
+}
+
+func TestWriteStatGroupMap(t *testing.T) {
+	cases := []struct {
+		desc           string
+		numGroups      int
+		shouldErrLabel bool
+		shouldErrStats bool
+	}{
+		{
+			desc:      "no labels",
+			numGroups: 0,
+		},
+		{
+			desc:      "one label",
+			numGroups: 1,
+		},
+		{
+			desc:      "two labels",
+			numGroups: 2,
+		},
+		{
+			desc:      "ten labels",
+			numGroups: 10,
+		},
+		{
+			desc:           "err on label",
+			numGroups:      1,
+			shouldErrLabel: true,
+		},
+		{
+			desc:           "err on stats",
+			numGroups:      1,
+			shouldErrStats: true,
+		},
+	}
+
+	for _, c := range cases {
+		m := map[string]*statGroup{}
+		orderedKeys := []string{}
+		for i := 0; i < c.numGroups; i++ {
+			sg := newStatGroup(uint64(i))
+			label := ""
+			for j := 0; j < (i + 1); j++ {
+				label += "a"
+			}
+			m[label] = sg
+
+			// we are generating labels in order
+			orderedKeys = append(orderedKeys, label)
+		}
+		shouldErr := c.shouldErrLabel || c.shouldErrStats
+
+		var w io.Writer
+		if c.shouldErrLabel {
+			w = &errWriter{}
+		} else if c.shouldErrStats {
+			w = &errWriter{skipOne: true}
+		} else {
+			w = bytes.NewBuffer([]byte{})
+		}
+		err := writeStatGroupMap(w, m)
+		if shouldErr {
+			ew := w.(*errWriter)
+			if err == nil {
+				t.Errorf("%s: did not error when it should", c.desc)
+			}
+
+			check := func(ew *errWriter, wantWrites int, wantErr string) {
+				if ew.writes != wantWrites {
+					t.Errorf("%s: too many writes for error case: got %d want %d", c.desc, ew.writes, wantWrites)
+				}
+				if got := err.Error(); got != wantErr {
+					t.Errorf("%s: unexpected err msg: got %s want %s", c.desc, got, wantErr)
+				}
+			}
+
+			if c.shouldErrLabel {
+				check(ew, 0, errWriterNormal)
+			} else if c.shouldErrStats {
+				check(ew, 1, errWriterSkipOne)
+			} else {
+				t.Errorf("%s: unexpected condition reached", c.desc)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", c.desc, err)
+			}
+			buf := w.(*bytes.Buffer)
+			text := string(buf.Bytes())
+
+			labelIndexes := []int{}
+			for _, l := range orderedKeys {
+				labelIndexes = append(labelIndexes, strings.Index(text, l))
+			}
+			// check labels are in order by checking indexes
+			prev := -1
+			for _, i := range labelIndexes {
+				if prev > i {
+					t.Errorf("%s: labels not alphabetical: got\n%s", c.desc, text)
+				}
+				prev = i
+			}
+
+			// check that labels are padded correctly
+			lines := strings.Split(text, "\n")
+			wantLen := c.numGroups*2 + 1 // two per group -- label & metrics -- plus newline
+			if got := len(lines); got != wantLen {
+				t.Errorf("%s: text is incorrect length: got %d want %d", c.desc, got, wantLen)
+			}
+			lines = lines[:len(lines)-1] // remove trailing new line
+			for i, line := range lines {
+				// label lines are every other one
+				if i%2 == 0 {
+					args := strings.Split(line, ":")
+					if got := len(args); got != 2 {
+						t.Errorf("%s: invalid label line, more than 2 parts: got %s", c.desc, line)
+					}
+					if got := len(args[0]); got != c.numGroups {
+						t.Errorf("%s: invalid label, not padded: '%s' is only len %d, not %d", c.desc, args[0], len(args[0]), c.numGroups)
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Also make writeStatGroupMap return an error instead of calling
fatal itself. Should try to restrict the amount of functions that
can directly call fatal or panic and make the more library-like
functions return errors instead.