### PR TITLE
provide file in/out support

### DIFF
--- a/cmd/tsbs_run_queries_timescaledb/main.go
+++ b/cmd/tsbs_run_queries_timescaledb/main.go
@@ -1,8 +1,8 @@
-// tsbs_run_queries_timescaledb speed tests TimescaleDB using requests from stdin.
+// tsbs_run_queries_timescaledb speed tests TimescaleDB using requests from stdin or file
 //
-// It reads encoded Query objects from stdin, and makes concurrent requests
-// to the provided PostgreSQL/TimescaleDB endpoint. This program has no knowledge of the
-// internals of the endpoint.
+// It reads encoded Query objects from stdin or file, and makes concurrent requests
+// to the provided PostgreSQL/TimescaleDB endpoint.
+// This program has no knowledge of the internals of the endpoint.
 package main
 
 import (

--- a/load/loader.go
+++ b/load/loader.go
@@ -53,7 +53,7 @@ type BenchmarkRunner struct {
 	doCreateDB      bool
 	doAbortOnExist  bool
 	reportingPeriod time.Duration
-	filename        string // TODO implement file reading
+	fileName        string
 
 	// non-flag fields
 	br        *bufio.Reader
@@ -81,6 +81,7 @@ func GetBenchmarkRunnerWithBatchSize(batchSize uint) *BenchmarkRunner {
 	flag.BoolVar(&loader.doCreateDB, "do-create-db", true, "Whether to create the database. Disable on all but one client if running on a multi client setup.")
 	flag.BoolVar(&loader.doAbortOnExist, "do-abort-on-exist", false, "Whether to abort if a database with the given name already exists.")
 	flag.DurationVar(&loader.reportingPeriod, "reporting-period", 10*time.Second, "Period to report write stats")
+	flag.StringVar(&loader.fileName, "file", "", "File name to read data from")
 
 	return loader
 }
@@ -120,9 +121,15 @@ func (l *BenchmarkRunner) RunBenchmark(b Benchmark, workQueues uint) {
 // GetBufferedReader returns the buffered Reader that should be used by the loader
 func (l *BenchmarkRunner) GetBufferedReader() *bufio.Reader {
 	if l.br == nil {
-		if len(l.filename) > 0 {
-			l.br = nil // TODO - Support reading from files
+		if len(l.fileName) > 0 {
+			// Read from specified file
+			file, err := os.Open(l.fileName)
+			if err != nil {
+				panic("cannot open file" + l.fileName)
+			}
+			l.br = bufio.NewReaderSize(file, defaultReadSize)
 		} else {
+			// Read from STDIN
 			l.br = bufio.NewReaderSize(os.Stdin, defaultReadSize)
 		}
 	}


### PR DESCRIPTION

Provide possibility to specify input/output filename for plain text files for all tools:
1. data generator
2. query generator
3. data loader
4. query runner

New option added:  `-file /path/to/file` (short form) or `--file=/path/to/file` (long form)

More discussion in [this issue](https://github.com/timescale/tsbs/issues/6#issuecomment-431955616)

Use-cases:

```
./tsbs_generate_data -format timescaledb -use-case cpu-only -scale-var 10 -seed 123 -file /tmp/bulk_data/timescaledb
./tsbs_generate_queries -format timescaledb -use-case cpu-only -scale-var 10 -seed 123 -query-type lastpoint -file /tmp/bulk_data/query_timescaledb
./tsbs_load_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
./tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_query
```
