### PR TITLE
Fileio

### DIFF
--- a/cmd/tsbs_run_queries_timescaledb/main.go
+++ b/cmd/tsbs_run_queries_timescaledb/main.go
@@ -1,8 +1,8 @@
-// tsbs_run_queries_timescaledb speed tests TimescaleDB using requests from stdin.
+// tsbs_run_queries_timescaledb speed tests TimescaleDB using requests from stdin or file
 //
-// It reads encoded Query objects from stdin, and makes concurrent requests
-// to the provided PostgreSQL/TimescaleDB endpoint. This program has no knowledge of the
-// internals of the endpoint.
+// It reads encoded Query objects from stdin or file, and makes concurrent requests
+// to the provided PostgreSQL/TimescaleDB endpoint.
+// This program has no knowledge of the internals of the endpoint.
 package main
 
 import (

--- a/load/loader_test.go
+++ b/load/loader_test.go
@@ -101,24 +101,50 @@ func TestGetBufferedReader(t *testing.T) {
 	if br != nil {
 		t.Errorf("initial buffered reader is non-nil")
 	}
-	// TODO Filename not yet supported
-	r.filename = "foo"
+
+	oldFatal := fatal
+	fatalCalled := false
+	fatal = func(format string, args ...interface{}) {
+		fatalCalled = true
+	}
+
+	// Should give a nil bufio.Reader
+	fatalCalled = false
+	r.fileName = "foo"
 	br = r.GetBufferedReader()
 	if br != nil {
-		t.Errorf("filename returned a non-nil buffered reader")
+		t.Errorf("filename returned not nil buffered reader for unexistent file")
 	}
-	// Should give a non-nil bufio.Reader now
-	r.filename = ""
+
+	if !fatalCalled {
+		t.Errorf("fatal not called when it should have been")
+	}
+
+	// Should give a non-nil bufio.Reader
+	fatalCalled = false
+	r.fileName = "/dev/null"
 	br = r.GetBufferedReader()
 	if br == nil {
-		t.Errorf("non-filename returned a nil buffered reader")
+		t.Errorf("filename returned nil buffered reader for /dev/null")
 	}
+
+	// Should give a non-nil bufio.Reader
+	fatalCalled = false
+	r.fileName = ""
+	br = r.GetBufferedReader()
+	if br == nil {
+		t.Errorf("STDOUT returned a nil buffered reader")
+	}
+
 	// Test that it returns same bufio.Reader as before
+	fatalCalled = false
 	old := br
 	br = r.GetBufferedReader()
 	if br != old {
 		t.Errorf("different buffered reader returned after previously set")
 	}
+
+	fatal = oldFatal
 }
 
 func TestUseDBCreator(t *testing.T) {

--- a/query/benchmarker.go
+++ b/query/benchmarker.go
@@ -15,6 +15,8 @@ const (
 	labelAllQueries  = "all queries"
 	labelColdQueries = "cold queries"
 	labelWarmQueries = "warm queries"
+
+	defaultReadSize  = 4 << 20 // 4 MB
 )
 
 // BenchmarkRunner contains the common components for running a query benchmarking
@@ -30,6 +32,9 @@ type BenchmarkRunner struct {
 	memProfile     string
 	printResponses bool
 	debug          int
+	fileName       string
+
+	br            *bufio.Reader
 }
 
 // NewBenchmarkRunner creates a new instance of BenchmarkRunner which is
@@ -49,6 +54,7 @@ func NewBenchmarkRunner() *BenchmarkRunner {
 	flag.BoolVar(&ret.sp.prewarmQueries, "prewarm-queries", false, "Run each query twice in a row so the warm query is guaranteed to be a cache hit")
 	flag.BoolVar(&ret.printResponses, "print-responses", false, "Pretty print response bodies for correctness checking (default false).")
 	flag.IntVar(&ret.debug, "debug", 0, "Whether to print debug messages.")
+	flag.StringVar(&ret.fileName, "file", "", "File name to read queries from")
 
 	return ret
 }
@@ -84,6 +90,24 @@ type Processor interface {
 	ProcessQuery(q Query, isWarm bool) ([]*Stat, error)
 }
 
+// GetBufferedReader returns the buffered Reader that should be used by the loader
+func (b *BenchmarkRunner) GetBufferedReader() *bufio.Reader {
+	if b.br == nil {
+		if len(b.fileName) > 0 {
+			// Read from specified file
+			file, err := os.Open(b.fileName)
+			if err != nil {
+				panic(fmt.Sprintf("cannot open file for read %s: %v", b.fileName, err))
+			}
+			b.br = bufio.NewReaderSize(file, defaultReadSize)
+		} else {
+			// Read from STDIN
+			b.br = bufio.NewReaderSize(os.Stdin, defaultReadSize)
+		}
+	}
+	return b.br
+}
+
 // Run does the bulk of the benchmark execution. It launches a gorountine to track
 // stats, creates workers to process queries, read in the input, execute the queries,
 // and then does cleanup.
@@ -107,9 +131,8 @@ func (b *BenchmarkRunner) Run(queryPool *sync.Pool, createFn ProcessorCreate) {
 	}
 
 	// Read in jobs, closing the job channel when done:
-	input := bufio.NewReaderSize(os.Stdin, 1<<20)
 	wallStart := time.Now()
-	b.scanner.setReader(input).scan(queryPool, b.c)
+	b.scanner.setReader(b.GetBufferedReader()).scan(queryPool, b.c)
 	close(b.c)
 
 	// Block for workers to finish sending requests, closing the stats


### PR DESCRIPTION
Provide possibility to specify input/output filename for plain text files for all tools:
1. data generator
2. query generator
3. data loader
4. query runner

New option added: `-file /path/to/file` (short form) or `--file=/path/to/file` (long form)

More discussion in [this issue](https://github.com/timescale/tsbs/issues/6#issuecomment-431955616)

Use-cases:
```
./tsbs_generate_data -format timescaledb -use-case cpu-only -scale-var 10 -seed 123 -file /tmp/bulk_data/timescaledb
./tsbs_generate_queries -format timescaledb -use-case cpu-only -scale-var 10 -seed 123 -query-type lastpoint -file /tmp/bulk_data/query_timescaledb
./tsbs_load_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
./tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_query
```

PS. Sorry for play with PR(s) I am still learning on how to perform inter-repo communication in github (that's why extra commits)