### PR TITLE
Add shell script to run test queries for TimescaleDB test case

### DIFF
--- a/scripts/generate_run_script.py
+++ b/scripts/generate_run_script.py
@@ -44,9 +44,9 @@ Result:
 NUM_WORKERS=8 BULK_DATA_DIR=/tmp DATABASE_HOST=localhost BATCH_SIZE=10000 ./load_timescaledb.sh | tee load_timescaledb_8_10000.out
 
 # Queries
-cat /tmp/queries/timescaledb-single-groupby-5-1-1-queries.gz | gunzip | tsbs_run_queries_timescaledb -workers 8 -limit 1000 -postgres "host=localhost user=postgres sslmode=disable" | tee query_timescaledb_timescaledb-single-groupby-5-1-1-queries.out
+cat /tmp/queries/timescaledb-single-groupby-5-1-1-queries.gz | gunzip | tsbs_run_queries_timescaledb -workers 8 -max-queries 1000 -postgres "host=localhost user=postgres sslmode=disable" | tee query_timescaledb_timescaledb-single-groupby-5-1-1-queries.out
 
-cat /tmp/queries/timescaledb-single-groupby-5-1-12-queries.gz | gunzip | tsbs_run_queries_timescaledb -workers 8 -limit 1000 -postgres "host=localhost user=postgres sslmode=disable" | tee query_timescaledb_timescaledb-single-groupby-5-1-12-queries.out
+cat /tmp/queries/timescaledb-single-groupby-5-1-12-queries.gz | gunzip | tsbs_run_queries_timescaledb -workers 8 -max-queries 1000 -postgres "host=localhost user=postgres sslmode=disable" | tee query_timescaledb_timescaledb-single-groupby-5-1-12-queries.out
 '''
 import argparse
 import os
@@ -69,7 +69,7 @@ def get_load_str(load_dir, label, batch_size, workers, hostname):
 
 def get_query_str(queryfile, label, workers, limit, hostname, extra_query_args):
     '''Writes a script line corresponding to executing a query on a database'''
-    limit_arg = '--limit={}'.format(limit) if limit is not None else ''
+    limit_arg = '--max-queries={}'.format(limit) if limit is not None else ''
     output_file = 'query_{}_{}'.format(label, queryfile.split('/')[-1]).split('.')[0]
     benchmarker = label if label != 'postgres' else 'timescaledb'
 
@@ -137,7 +137,7 @@ if __name__ == "__main__":
         action='store_true', help='Whether to only generate commands for inserts')
     parser.add_argument('-l', dest='load_file_dir', default=default_load_dir,
         type=str, help='Path to directory where data to insert is stored')
-    parser.add_argument('-n', dest='limit', default=1000, type=int,
+    parser.add_argument('-n', dest='max-queries', default=1000, type=int,
         help='Max number of queries to run')
     parser.add_argument('-o', dest='query_file_dir', default=default_query_dir,
         type=str, help='Path to directory where queries to execute are stored')

--- a/scripts/run_queries_timescaledb.sh
+++ b/scripts/run_queries_timescaledb.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Ensure runner is available
+EXE_FILE_NAME=${EXE_FILE_NAME:-$(which tsbs_run_queries_timescaledb)}
+if [[ -z "$EXE_FILE_NAME" ]]; then
+    echo "tsbs_run_queries_timescaledb not available. It is not specified explicitly and not found in \$PATH"
+    exit 1
+fi
+
+# Queries folder
+BULK_DATA_DIR=${BULK_DATA_DIR:-"/tmp/bulk_queries"}
+
+# How many queries would be run
+MAX_QUERIES=${MAX_QUERIES:-"0"}
+
+# How many concurrent worker would run queries - match num of cores, or default to 4
+NUM_WORKERS=${NUM_WORKERS:-$(grep -c ^processor /proc/cpuinfo 2> /dev/null || echo 4)}
+
+for FULL_DATA_FILE_NAME in ${BULK_DATA_DIR}/queries_timescaledb*; do
+    # $FULL_DATA_FILE_NAME:  /full/path/to/file_with.ext
+    # $DATA_FILE_NAME:       file_with.ext
+    # $DIR:                  /full/path/to
+    # $EXTENSION:            ext
+    # NO_EXT_DATA_FILE_NAME: file_with
+
+    DATA_FILE_NAME=$(basename -- "${FULL_DATA_FILE_NAME}")
+    DIR=$(dirname "${FULL_DATA_FILE_NAME}")
+    EXTENSION="${DATA_FILE_NAME##*.}"
+    NO_EXT_DATA_FILE_NAME="${DATA_FILE_NAME%.*}"
+
+    # Several options on how to name results file
+    #OUT_FULL_FILE_NAME="${DIR}/result_${DATA_FILE_NAME}"
+    OUT_FULL_FILE_NAME="${DIR}/result_${NO_EXT_DATA_FILE_NAME}.out"
+    #OUT_FULL_FILE_NAME="${DIR}/${NO_EXT_DATA_FILE_NAME}.out"
+
+    if [ "${EXTENSION}" == "gz" ]; then
+        GUNZIP="gunzip"
+    else
+        GUNZIP="cat"
+    fi
+
+    echo "Running ${DATA_FILE_NAME}"
+    cat $FULL_DATA_FILE_NAME \
+        | $GUNZIP \
+        | $EXE_FILE_NAME \
+            -max-queries $MAX_QUERIES \
+            -workers $NUM_WORKERS \
+        | tee $OUT_FULL_FILE_NAME
+done


### PR DESCRIPTION
1. Add new script running queries. This runner script uses '--max-queries' CLI flag, which limits number of test queues. Handy when you'd like to make short test session.
2. Update generate_run_script.py to honor '--max-queries' CLI flag, instead of previously used '--limit' flag, which is ambiguous