### PR TITLE
Fix tsbs_generate_data printing of tags

### DIFF
--- a/cmd/tsbs_generate_data/common/simulation.go
+++ b/cmd/tsbs_generate_data/common/simulation.go
@@ -16,6 +16,7 @@ type Simulator interface {
 	Finished() bool
 	Next(*serialize.Point) bool
 	Fields() map[string][][]byte
+	TagKeys() [][]byte
 }
 
 // SimulatedMeasurement simulates one measurement (e.g. Redis for DevOps).

--- a/cmd/tsbs_generate_data/devops/common_generate_data.go
+++ b/cmd/tsbs_generate_data/devops/common_generate_data.go
@@ -53,6 +53,10 @@ func (s *commonDevopsSimulator) Fields() map[string][][]byte {
 	return s.fields(s.hosts[0].SimulatedMeasurements)
 }
 
+func (s *commonDevopsSimulator) TagKeys() [][]byte {
+	return MachineTagKeys
+}
+
 func (s *commonDevopsSimulator) fields(measurements []common.SimulatedMeasurement) map[string][][]byte {
 	data := make(map[string][][]byte)
 	for _, sm := range measurements {

--- a/cmd/tsbs_generate_data/main.go
+++ b/cmd/tsbs_generate_data/main.go
@@ -302,7 +302,7 @@ func getSerializer(sim common.Simulator, format string, out *bufio.Writer) seria
 		fallthrough
 	case formatTimescaleDB:
 		out.WriteString("tags")
-		for _, key := range devops.MachineTagKeys {
+		for _, key := range sim.TagKeys() {
 			out.WriteString(",")
 			out.Write(key)
 		}

--- a/cmd/tsbs_generate_data/main_test.go
+++ b/cmd/tsbs_generate_data/main_test.go
@@ -192,6 +192,10 @@ func (s *testSimulator) Fields() map[string][][]byte {
 	return nil
 }
 
+func (s *testSimulator) TagKeys() [][]byte {
+	return nil
+}
+
 type testSerializer struct {
 	shouldError bool
 }


### PR DESCRIPTION
Previously, for TimescaleDB, the output of tsbs_generate_data would always
include the full devops tags rather than dynamically printing based on the use
case. Now the tag keys are exposed via the Simulator interface and printed correctly.

Replaces #44 , which closes #43 