### PR TITLE
Fix spelling mistakes

### DIFF
--- a/cmd/tsbs_generate_queries/databases/cassandra/devops.go
+++ b/cmd/tsbs_generate_queries/databases/cassandra/devops.go
@@ -42,7 +42,7 @@ func (d *Devops) getHostWhere(nHosts int) []string {
 
 // GroupByTime selects the MAX for numMetrics metrics under 'cpu',
 // per minute for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT minute, max(metric1), ..., max(metricN)
 // FROM cpu
@@ -83,7 +83,7 @@ func (d *Devops) GroupByOrderByLimit(qi query.Query) {
 }
 
 // GroupByTimeAndPrimaryTag selects the AVG of numMetrics metrics under 'cpu' per device per hour for a day,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT AVG(metric1), ..., AVG(metricN)
 // FROM cpu
@@ -101,7 +101,7 @@ func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 }
 
 // MaxAllCPU selects the MAX of all metrics under 'cpu' per hour for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT MAX(metric1), ..., MAX(metricN)
 // FROM cpu WHERE (hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
@@ -133,7 +133,7 @@ func (d *Devops) LastPointPerHost(qi query.Query) {
 
 // HighCPUForHosts populates a query that gets CPU metrics when the CPU has high
 // usage between a time period for a number of hosts (if 0, it will search all hosts),
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT * FROM cpu
 // WHERE usage_user > 90.0

--- a/cmd/tsbs_generate_queries/databases/influx/devops.go
+++ b/cmd/tsbs_generate_queries/databases/influx/devops.go
@@ -51,7 +51,7 @@ func (d *Devops) getSelectClausesAggMetrics(agg string, metrics []string) []stri
 
 // GroupByTime selects the MAX for numMetrics metrics under 'cpu',
 // per minute for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT minute, max(metric1), ..., max(metricN)
 // FROM cpu
@@ -86,7 +86,7 @@ func (d *Devops) GroupByOrderByLimit(qi query.Query) {
 }
 
 // GroupByTimeAndPrimaryTag selects the AVG of numMetrics metrics under 'cpu' per device per hour for a day,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT AVG(metric1), ..., AVG(metricN)
 // FROM cpu
@@ -104,7 +104,7 @@ func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 }
 
 // MaxAllCPU selects the MAX of all metrics under 'cpu' per hour for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT MAX(metric1), ..., MAX(metricN)
 // FROM cpu WHERE (hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
@@ -131,7 +131,7 @@ func (d *Devops) LastPointPerHost(qi query.Query) {
 
 // HighCPUForHosts populates a query that gets CPU metrics when the CPU has high
 // usage between a time period for a number of hosts (if 0, it will search all hosts),
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT * FROM cpu
 // WHERE usage_user > 90.0

--- a/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
+++ b/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
@@ -36,7 +36,7 @@ func (d *NaiveDevops) GenerateEmptyQuery() query.Query {
 
 // GroupByTime selects the MAX for numMetrics metrics under 'cpu',
 // per minute for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT minute, max(metric1), ..., max(metricN)
 // FROM cpu
@@ -98,7 +98,7 @@ func (d *NaiveDevops) GroupByTime(qi query.Query, nHosts, numMetrics int, timeRa
 }
 
 // GroupByTimeAndPrimaryTag selects the AVG of numMetrics metrics under 'cpu' per device per hour for a day,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT AVG(metric1), ..., AVG(metricN)
 // FROM cpu

--- a/cmd/tsbs_generate_queries/databases/mongo/devops.go
+++ b/cmd/tsbs_generate_queries/databases/mongo/devops.go
@@ -93,7 +93,7 @@ func getTimeFilterDocs(interval utils.TimeInterval) []interface{} {
 
 // GroupByTime selects the MAX for numMetrics metrics under 'cpu',
 // per minute for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT minute, max(metric1), ..., max(metricN)
 // FROM cpu
@@ -162,7 +162,7 @@ func (d *Devops) GroupByTime(qi query.Query, nHosts, numMetrics int, timeRange t
 }
 
 // MaxAllCPU selects the MAX of all metrics under 'cpu' per hour for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT MAX(metric1), ..., MAX(metricN)
 // FROM cpu WHERE (hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
@@ -230,7 +230,7 @@ func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
 }
 
 // GroupByTimeAndPrimaryTag selects the AVG of numMetrics metrics under 'cpu' per device per hour for a day,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT AVG(metric1), ..., AVG(metricN)
 // FROM cpu
@@ -310,7 +310,7 @@ func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 
 // HighCPUForHosts populates a query that gets CPU metrics when the CPU has high
 // usage between a time period for a number of hosts (if 0, it will search all hosts),
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT * FROM cpu
 // WHERE usage_user > 90.0

--- a/cmd/tsbs_generate_queries/databases/timescaledb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/timescaledb/devops.go
@@ -81,7 +81,7 @@ const goTimeFmt = "2006-01-02 15:04:05.999999 -0700"
 
 // GroupByTime selects the MAX for numMetrics metrics under 'cpu',
 // per minute for nhosts hosts,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT minute, max(metric1), ..., max(metricN)
 // FROM cpu
@@ -131,7 +131,7 @@ func (d *Devops) GroupByOrderByLimit(qi query.Query) {
 }
 
 // GroupByTimeAndPrimaryTag selects the AVG of numMetrics metrics under 'cpu' per device per hour for a day,
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT AVG(metric1), ..., AVG(metricN)
 // FROM cpu
@@ -226,7 +226,7 @@ func (d *Devops) LastPointPerHost(qi query.Query) {
 
 // HighCPUForHosts populates a query that gets CPU metrics when the CPU has high
 // usage between a time period for a number of hosts (if 0, it will search all hosts),
-// e.g. in psuedo-SQL:
+// e.g. in pseudo-SQL:
 //
 // SELECT * FROM cpu
 // WHERE usage_user > 90.0

--- a/cmd/tsbs_load_timescaledb/process_test.go
+++ b/cmd/tsbs_load_timescaledb/process_test.go
@@ -32,7 +32,7 @@ func TestSubsystemTagsToJSON(t *testing.T) {
 
 	for _, c := range cases {
 		if got := subsystemTagsToJSON(c.tags); got != c.want {
-			t.Errorf("%s: incorrect ouput: got %s want %s", c.desc, got, c.want)
+			t.Errorf("%s: incorrect output: got %s want %s", c.desc, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
Pseudo was incorrectly spelled as 'psuedo' and it was propagating
everywhere. Also a test had 'ouput' instead of 'output'.