### PR TITLE
Split TS load data processing into own function

### DIFF
--- a/cmd/tsbs_load_timescaledb/creator.go
+++ b/cmd/tsbs_load_timescaledb/creator.go
@@ -9,6 +9,10 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+const tagsKey = "tags"
+
+var tableCols = make(map[string][]string)
+
 type dbCreator struct {
 	br      *bufio.Reader
 	tags    string
@@ -77,16 +81,16 @@ func (d *dbCreator) CreateDB(dbName string) error {
 	defer dbBench.Close()
 
 	parts := strings.Split(strings.TrimSpace(d.tags), ",")
-	if parts[0] != "tags" {
+	if parts[0] != tagsKey {
 		return fmt.Errorf("input header in wrong format. got '%s', expected 'tags'", parts[0])
 	}
 	createTagsTable(dbBench, parts[1:])
-	tableCols["tags"] = parts[1:]
+	tableCols[tagsKey] = parts[1:]
 
 	for _, cols := range d.cols {
 		parts = strings.Split(strings.TrimSpace(cols), ",")
 		hypertable := parts[0]
-		partitioningField := tableCols["tags"][0]
+		partitioningField := tableCols[tagsKey][0]
 		tableCols[hypertable] = parts[1:]
 
 		psuedoCols := []string{}

--- a/cmd/tsbs_load_timescaledb/main.go
+++ b/cmd/tsbs_load_timescaledb/main.go
@@ -55,10 +55,7 @@ type insertData struct {
 }
 
 // Global vars
-var (
-	loader    *load.BenchmarkRunner
-	tableCols map[string][]string
-)
+var loader *load.BenchmarkRunner
 
 // allows for testing
 var fatal = log.Fatalf
@@ -92,7 +89,6 @@ func init() {
 	flag.StringVar(&replicationStatsFile, "write-replication-stats", "", "File to output replication stats to")
 
 	flag.Parse()
-	tableCols = make(map[string][]string)
 }
 
 type benchmark struct{}

--- a/cmd/tsbs_load_timescaledb/process_test.go
+++ b/cmd/tsbs_load_timescaledb/process_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+	"time"
+)
 
 func TestSubsystemTagsToJSON(t *testing.T) {
 	cases := []struct {
@@ -34,5 +38,157 @@ func TestSubsystemTagsToJSON(t *testing.T) {
 		if got := subsystemTagsToJSON(c.tags); got != c.want {
 			t.Errorf("%s: incorrect output: got %s want %s", c.desc, got, c.want)
 		}
+	}
+}
+
+func TestSplitTagsAndMetrics(t *testing.T) {
+	numCols := 3
+	tableCols[tagsKey] = []string{"tag1", "tag2"}
+	toTS := func(s string) string {
+		timeInt, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		return time.Unix(0, timeInt).Format(time.RFC3339)
+	}
+
+	justTagsData := []*insertData{
+		{
+			tags:   "tag1=foo,tag2=bar",
+			fields: "100,1,5,42",
+		},
+		{
+			tags:   "tag1=foofoo,tag2=barbar",
+			fields: "200,1,5,45",
+		},
+	}
+
+	extraTagsData := []*insertData{
+		{
+			tags:   "tag1=foo,tag2=bar,tag3=baz",
+			fields: "100,1,5,42",
+		},
+		{
+			tags:   "tag1=foofoo,tag2=barbar,tag3=BAZ",
+			fields: "200,1,5,45",
+		},
+	}
+
+	cases := []struct {
+		desc        string
+		rows        []*insertData
+		inTableTag  bool
+		wantMetrics uint64
+		wantTags    [][]string
+		wantData    [][]interface{}
+		shouldPanic bool
+	}{
+		{
+			desc:        "just common tags",
+			rows:        justTagsData,
+			wantMetrics: 6,
+			wantTags:    [][]string{{"foo", "bar"}, {"foofoo", "barbar"}},
+			wantData: [][]interface{}{
+				[]interface{}{toTS("100"), nil, nil, "1", "5", "42"},
+				[]interface{}{toTS("200"), nil, nil, "1", "5", "45"},
+			},
+		},
+		{
+			desc:        "extra tags",
+			rows:        extraTagsData,
+			wantMetrics: 6,
+			wantTags:    [][]string{{"foo", "bar"}, {"foofoo", "barbar"}},
+			wantData: [][]interface{}{
+				[]interface{}{toTS("100"), nil, "{\"tag3\": \"baz\"}", "1", "5", "42"},
+				[]interface{}{toTS("200"), nil, "{\"tag3\": \"BAZ\"}", "1", "5", "45"},
+			},
+		},
+		{
+			desc:        "just common, in table tag",
+			inTableTag:  true,
+			rows:        justTagsData,
+			wantMetrics: 6,
+			wantTags:    [][]string{{"foo", "bar"}, {"foofoo", "barbar"}},
+			wantData: [][]interface{}{
+				[]interface{}{toTS("100"), nil, nil, "foo", "1", "5", "42"},
+				[]interface{}{toTS("200"), nil, nil, "foofoo", "1", "5", "45"},
+			},
+		},
+		{
+			desc:        "extra tags",
+			inTableTag:  true,
+			rows:        extraTagsData,
+			wantMetrics: 6,
+			wantTags:    [][]string{{"foo", "bar"}, {"foofoo", "barbar"}},
+			wantData: [][]interface{}{
+				[]interface{}{toTS("100"), nil, "{\"tag3\": \"baz\"}", "foo", "1", "5", "42"},
+				[]interface{}{toTS("200"), nil, "{\"tag3\": \"BAZ\"}", "foofoo", "1", "5", "45"},
+			},
+		},
+		{
+			desc: "invalid timestamp",
+			rows: []*insertData{
+				{
+					tags:   "tag1=foo,tag2=bar,tag3=baz",
+					fields: "not_a_timestamp,1,5,42",
+				},
+			},
+			shouldPanic: true,
+		},
+	}
+
+	for _, c := range cases {
+		if c.shouldPanic {
+			defer func() {
+				if re := recover(); re == nil {
+					t.Errorf("%s: did not panic when should", c.desc)
+				}
+			}()
+			splitTagsAndMetrics(c.rows, numCols+numExtraCols)
+		}
+
+		oldInTableTag := inTableTag
+		inTableTag = c.inTableTag
+
+		gotTags, gotData, numMetrics := splitTagsAndMetrics(c.rows, numCols+numExtraCols)
+		if numMetrics != c.wantMetrics {
+			t.Errorf("%s: number of metrics incorrect: got %d want %d", c.desc, numMetrics, c.wantMetrics)
+		}
+
+		if got := len(gotTags); got != len(c.wantTags) {
+			t.Errorf("%s: tags output not the same len: got %d want %d", c.desc, got, len(c.wantTags))
+		} else {
+			for i, row := range gotTags {
+				if got := len(row); got != len(c.wantTags[i]) {
+					t.Errorf("%s: tags output not same len for row %d: got %d want %d", c.desc, i, got, len(c.wantTags[i]))
+				} else {
+					for j, tag := range row {
+						want := c.wantTags[i][j]
+						if got := tag; got != want {
+							t.Errorf("%s: tag incorrect at %d, %d: got %s want %s", c.desc, i, j, got, want)
+						}
+					}
+				}
+			}
+		}
+
+		if got := len(gotData); got != len(c.wantData) {
+			t.Errorf("%s: data ouput not the same len: got %d want %d", c.desc, got, len(c.wantData))
+		} else {
+			for i, row := range gotData {
+				if got := len(row); got != len(c.wantData[i]) {
+					t.Errorf("%s: data output not same len for row %d: got %d want %d", c.desc, i, got, len(c.wantTags[i]))
+				} else {
+					for j, tag := range row {
+						want := c.wantData[i][j]
+						if got := tag; got != want {
+							t.Errorf("%s: data incorrect at %d, %d: got %v want %v", c.desc, i, j, got, want)
+						}
+					}
+				}
+			}
+		}
+
+		inTableTag = oldInTableTag
 	}
 }

--- a/cmd/tsbs_load_timescaledb/scan.go
+++ b/cmd/tsbs_load_timescaledb/scan.go
@@ -56,7 +56,7 @@ type decoder struct {
 	scanner *bufio.Scanner
 }
 
-const tagsPrefix = "tags"
+const tagsPrefix = tagsKey
 
 func (d *decoder) Decode(_ *bufio.Reader) *load.Point {
 	data := &insertData{}


### PR DESCRIPTION
To improve the testability of the tsbs_load_timescaledb binary and
reduce the complexity of some of its most complex function, we split
the processing of the insertData slice into tags and data into its
own function. This separates a non-DB task from a DB task so that
the former can be tested without an adequate mock for the latter.