### PR TITLE
Handle JSON tags properly on tsbs_load_timescaledb

### DIFF
--- a/cmd/tsbs_load_timescaledb/process.go
+++ b/cmd/tsbs_load_timescaledb/process.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -91,7 +92,16 @@ func insertTags(db *sqlx.DB, tagRows [][]string, returnResults bool) map[string]
 			if err != nil {
 				panic(err)
 			}
-			ret[fmt.Sprintf("%v", resVals[1])] = resVals[0].(int64)
+
+			var key string
+			if useJSON {
+				decodedTagset := map[string]string{}
+				json.Unmarshal(resVals[1].([]byte), &decodedTagset)
+				key = decodedTagset[tagCols[0]]
+			} else {
+				key = fmt.Sprintf("%v", resVals[1])
+			}
+			ret[key] = resVals[0].(int64)
 		}
 		res.Close()
 		return ret


### PR DESCRIPTION
Previously the returned values from insert tags assumed the data
was stored in a table and tried to use the first column as the key
to the client-side index. However, for JSON this first column was
a byte array representing the tags JSON, which created a mapping
with the wrong keys. Now, the JSON is unmarshalled first and then
the value corresponding to the first tags column is used as a key.

Updated version of #48, which fixes #47.