### PR TITLE
Separate db create from schema create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 .DS_Store
 .idea
+.vscode

--- a/cmd/tsbs_load_timescaledb/main.go
+++ b/cmd/tsbs_load_timescaledb/main.go
@@ -47,6 +47,8 @@ var (
 
 	profileFile          string
 	replicationStatsFile string
+
+	createMetricsTable bool
 )
 
 type insertData struct {
@@ -87,6 +89,7 @@ func init() {
 
 	flag.StringVar(&profileFile, "write-profile", "", "File to output CPU/memory profile to")
 	flag.StringVar(&replicationStatsFile, "write-replication-stats", "", "File to output replication stats to")
+	flag.BoolVar(&createMetricsTable, "create-metrics-table", true, "Drops existing and creates new metrics table. Can be used for both regular and hypertable")
 
 	flag.Parse()
 }


### PR DESCRIPTION
There are some cases when database needs to be configured/setup in a certain way (eg. setup db using some other tooling). So preferably you'd only want to drop the metrics table and create a new one and leave the rest of db intact.