### PR TITLE
Fix broken query output and minor other nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Variables needed:
 1. a start time for the data's timestamps. E.g., `2016-01-01T00:00:00Z`
 1. an end time. E.g., `2016-01-04T00:00:00Z`
 1. how much time should be between each reading per device, in seconds. E.g., `10s`
-1. and which database(s) you want to generate for. E.g., `timescaledb` (choose from `cassandra`, `influx`, `mongo`, `clickhouse`, `siridb` or `timescaledb`)
+1. and which database(s) you want to generate for. E.g., `timescaledb` (choose from `cassandra`, `clickhouse`, `influx`, `mongo`, `siridb` or `timescaledb`)
 
 Given the above steps you can now generate a dataset (or multiple
 datasets, if you chose to generate for multiple databases) that can

--- a/cmd/tsbs_generate_queries/databases/timescaledb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/timescaledb/devops.go
@@ -92,8 +92,11 @@ func (d *Devops) GroupByTime(qi query.Query, nHosts, numMetrics int, timeRange t
 	interval := d.Interval.RandWindow(timeRange)
 	metrics := devops.GetCPUMetricsSlice(numMetrics)
 	selectClauses := d.getSelectClausesAggMetrics("max", metrics)
+	if len(selectClauses) < 1 {
+		panic(fmt.Sprintf("invalid number of select clauses: got %d", len(selectClauses)))
+	}
 
-	sql := fmt.Sprintf(`SELECT %s AS minute
+	sql := fmt.Sprintf(`SELECT %s AS minute,
         %s
         FROM cpu
         WHERE %s AND time >= '%s' AND time < '%s'

--- a/scripts/generate_queries.sh
+++ b/scripts/generate_queries.sh
@@ -14,6 +14,7 @@ BULK_DATA_DIR=${BULK_DATA_DIR:-"/tmp/bulk_queries"}
 # Form of data to generate
 USE_JSON=${USE_JSON:-false}
 USE_TAGS=${USE_TAGS:-true}
+USE_TIME_BUCKET=${USE_TIME_BUCKET:-true}
 
 # Space-separated list of target DB formats to generate
 FORMATS=${FORMATS:-"timescaledb"}
@@ -87,12 +88,13 @@ for QUERY_TYPE in ${QUERY_TYPES}; do
                 -use-case ${USE_CASE} \
                 -timescale-use-json=${USE_JSON} \
                 -timescale-use-tags=${USE_TAGS} \
+                -timescale-use-time-bucket=${USE_TIME_BUCKET} \
                 -clickhouse-use-tags=${USE_TAGS} \
             | gzip  > ${DATA_FILE_NAME}
 
             trap - EXIT
             # Make short symlink for convenience
-            SYMLINK_NAME="${FORMAT}-queries.gz"
+            SYMLINK_NAME="${FORMAT}-${QUERY_TYPE}-queries.gz"
 
             rm -f ${SYMLINK_NAME} 2> /dev/null
             ln -s ${DATA_FILE_NAME} ${SYMLINK_NAME}


### PR DESCRIPTION
The single-group-by queries SQL for TimescaleDB was missing a comma
after the time grouping, creating an incorrect SQL statement. In
addition, a sanity check is added to make sure there are other
select clauses besides just the time grouping.

This also includes minor nits including:
 - fixing the alphabetical order in the README
 - have the generate_queries script output a symlink per query
 - add support for the -timescaledb-use-time-bucket flag to scripts