### PR TITLE
Add ability to explicitly specify postgres port and passsword

### DIFF
--- a/cmd/tsbs_load_timescaledb/main_test.go
+++ b/cmd/tsbs_load_timescaledb/main_test.go
@@ -9,7 +9,7 @@ func TestGetConnectString(t *testing.T) {
 	wantHost := "localhost"
 	wantDB := "benchmark"
 	wantUser := "postgres"
-	want := fmt.Sprintf("host=%s dbname=%s user=%s ssl=disable", wantHost, wantDB, wantUser)
+	want := fmt.Sprintf("host=%s dbname=%s user=%s ssl=disable port=5432", wantHost, wantDB, wantUser)
 	cases := []struct {
 		desc      string
 		pgConnect string


### PR DESCRIPTION
Using the -pass and -port flags, users can now specify custom ports and
passwords without having to override the connection string using the
-postgres parameter.