### PR TITLE
Move tag creation to creator.go for TimescaleDB 

### DIFF
--- a/cmd/tsbs_load_timescaledb/creator.go
+++ b/cmd/tsbs_load_timescaledb/creator.go
@@ -80,77 +80,94 @@ func (d *dbCreator) CreateDB(dbName string) error {
 }
 
 func (d *dbCreator) PostCreateDB(dbName string) error {
-	if createMetricsTable {
-		dbBench := sqlx.MustConnect(dbType, getConnectString())
-		defer dbBench.Close()
+	if !createMetricsTable {
+		return nil
+	}
 
-		parts := strings.Split(strings.TrimSpace(d.tags), ",")
-		if parts[0] != tagsKey {
-			return fmt.Errorf("input header in wrong format. got '%s', expected 'tags'", parts[0])
+	dbBench := sqlx.MustConnect(dbType, getConnectString())
+	defer dbBench.Close()
+
+	parts := strings.Split(strings.TrimSpace(d.tags), ",")
+	if parts[0] != tagsKey {
+		return fmt.Errorf("input header in wrong format. got '%s', expected 'tags'", parts[0])
+	}
+	createTagsTable(dbBench, parts[1:])
+	tableCols[tagsKey] = parts[1:]
+
+	for _, cols := range d.cols {
+		parts = strings.Split(strings.TrimSpace(cols), ",")
+		hypertable := parts[0]
+		partitioningField := tableCols[tagsKey][0]
+		tableCols[hypertable] = parts[1:]
+
+		pseudoCols := []string{}
+		if inTableTag {
+			pseudoCols = append(pseudoCols, partitioningField)
 		}
-		createTagsTable(dbBench, parts[1:])
-		tableCols[tagsKey] = parts[1:]
 
-		for _, cols := range d.cols {
-			parts = strings.Split(strings.TrimSpace(cols), ",")
-			hypertable := parts[0]
-			partitioningField := tableCols[tagsKey][0]
-			tableCols[hypertable] = parts[1:]
-
-			pseudoCols := []string{}
-			if inTableTag {
-				pseudoCols = append(pseudoCols, partitioningField)
+		fieldDef := []string{}
+		indexes := []string{}
+		pseudoCols = append(pseudoCols, parts[1:]...)
+		extraCols := 0 // set to 1 when hostname is kept in-table
+		for idx, field := range pseudoCols {
+			if len(field) == 0 {
+				continue
+			}
+			fieldType := "DOUBLE PRECISION"
+			idxType := fieldIndex
+			if inTableTag && idx == 0 {
+				fieldType = "TEXT"
+				idxType = ""
+				extraCols = 1
 			}
 
-			fieldDef := []string{}
-			indexes := []string{}
-			pseudoCols = append(pseudoCols, parts[1:]...)
-			extraCols := 0 // set to 1 when hostname is kept in-table
-			for idx, field := range pseudoCols {
-				if len(field) == 0 {
-					continue
-				}
-				fieldType := "DOUBLE PRECISION"
-				idxType := fieldIndex
-				if inTableTag && idx == 0 {
-					fieldType = "TEXT"
-					idxType = ""
-					extraCols = 1
-				}
+			fieldDef = append(fieldDef, fmt.Sprintf("%s %s", field, fieldType))
+			if fieldIndexCount == -1 || idx < (fieldIndexCount+extraCols) {
+				indexes = append(indexes, d.getCreateIndexOnFieldCmds(hypertable, field, idxType)...)
+			}
+		}
+		dbBench.MustExec(fmt.Sprintf("DROP TABLE IF EXISTS %s", hypertable))
+		dbBench.MustExec(fmt.Sprintf("CREATE TABLE %s (time timestamptz, tags_id integer, %s, additional_tags JSONB DEFAULT NULL)", hypertable, strings.Join(fieldDef, ",")))
+		if partitionIndex {
+			dbBench.MustExec(fmt.Sprintf("CREATE INDEX ON %s(tags_id, \"time\" DESC)", hypertable))
+		}
 
-				fieldDef = append(fieldDef, fmt.Sprintf("%s %s", field, fieldType))
-				if fieldIndexCount == -1 || idx < (fieldIndexCount+extraCols) {
-					indexes = append(indexes, d.getCreateIndexOnFieldCmds(hypertable, field, idxType)...)
-				}
-			}
-			dbBench.MustExec(fmt.Sprintf("DROP TABLE IF EXISTS %s", hypertable))
-			dbBench.MustExec(fmt.Sprintf("CREATE TABLE %s (time timestamptz, tags_id integer, %s, additional_tags JSONB DEFAULT NULL)", hypertable, strings.Join(fieldDef, ",")))
-			if partitionIndex {
-				dbBench.MustExec(fmt.Sprintf("CREATE INDEX ON %s(tags_id, \"time\" DESC)", hypertable))
-			}
+		// Only allow one or the other, it's probably never right to have both.
+		// Experimentation suggests (so far) that for 100k devices it is better to
+		// use --time-partition-index for reduced index lock contention.
+		if timePartitionIndex {
+			dbBench.MustExec(fmt.Sprintf("CREATE INDEX ON %s(\"time\" DESC, tags_id)", hypertable))
+		} else if timeIndex {
+			dbBench.MustExec(fmt.Sprintf("CREATE INDEX ON %s(\"time\" DESC)", hypertable))
+		}
 
-			// Only allow one or the other, it's probably never right to have both.
-			// Experimentation suggests (so far) that for 100k devices it is better to
-			// use --time-partition-index for reduced index lock contention.
-			if timePartitionIndex {
-				dbBench.MustExec(fmt.Sprintf("CREATE INDEX ON %s(\"time\" DESC, tags_id)", hypertable))
-			} else if timeIndex {
-				dbBench.MustExec(fmt.Sprintf("CREATE INDEX ON %s(\"time\" DESC)", hypertable))
-			}
+		for _, idxDef := range indexes {
+			dbBench.MustExec(idxDef)
+		}
 
-			for _, idxDef := range indexes {
-				dbBench.MustExec(idxDef)
-			}
-
-			if useHypertable {
-				dbBench.MustExec("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
-				dbBench.MustExec(
-					fmt.Sprintf("SELECT create_hypertable('%s'::regclass, 'time'::name, partitioning_column => '%s'::name, number_partitions => %v::smallint, chunk_time_interval => %d, create_default_indexes=>FALSE)",
-						hypertable, "tags_id", numberPartitions, chunkTime.Nanoseconds()/1000))
-			}
+		if useHypertable {
+			dbBench.MustExec("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
+			dbBench.MustExec(
+				fmt.Sprintf("SELECT create_hypertable('%s'::regclass, 'time'::name, partitioning_column => '%s'::name, number_partitions => %v::smallint, chunk_time_interval => %d, create_default_indexes=>FALSE)",
+					hypertable, "tags_id", numberPartitions, chunkTime.Nanoseconds()/1000))
 		}
 	}
 	return nil
+}
+
+func createTagsTable(db *sqlx.DB, tags []string) {
+	db.MustExec("DROP TABLE IF EXISTS tags")
+	if useJSON {
+		db.MustExec("CREATE TABLE tags(id SERIAL PRIMARY KEY, tagset JSONB)")
+		db.MustExec("CREATE UNIQUE INDEX uniq1 ON tags(tagset)")
+		db.MustExec("CREATE INDEX idxginp ON tags USING gin (tagset jsonb_path_ops);")
+	} else {
+		cols := strings.Join(tags, " TEXT, ")
+		cols += " TEXT"
+		db.MustExec(fmt.Sprintf("CREATE TABLE tags(id SERIAL PRIMARY KEY, %s)", cols))
+		db.MustExec(fmt.Sprintf("CREATE UNIQUE INDEX uniq1 ON tags(%s)", strings.Join(tags, ",")))
+		db.MustExec(fmt.Sprintf("CREATE INDEX ON tags(%s)", tags[0]))
+	}
 }
 
 func (d *dbCreator) getCreateIndexOnFieldCmds(hypertable, field, idxType string) []string {

--- a/cmd/tsbs_load_timescaledb/main.go
+++ b/cmd/tsbs_load_timescaledb/main.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"github.com/timescale/tsbs/load"
 )
@@ -164,18 +163,4 @@ func getConnectString() string {
 	}
 
 	return connectString
-}
-
-func createTagsTable(db *sqlx.DB, tags []string) {
-	if useJSON {
-		db.MustExec("CREATE TABLE tags(id SERIAL PRIMARY KEY, tagset JSONB)")
-		db.MustExec("CREATE UNIQUE INDEX uniq1 ON tags(tagset)")
-		db.MustExec("CREATE INDEX idxginp ON tags USING gin (tagset jsonb_path_ops);")
-	} else {
-		cols := strings.Join(tags, " TEXT, ")
-		cols += " TEXT"
-		db.MustExec(fmt.Sprintf("CREATE TABLE tags(id SERIAL PRIMARY KEY, %s)", cols))
-		db.MustExec(fmt.Sprintf("CREATE UNIQUE INDEX uniq1 ON tags(%s)", strings.Join(tags, ",")))
-		db.MustExec(fmt.Sprintf("CREATE INDEX ON tags(%s)", tags[0]))
-	}
 }


### PR DESCRIPTION
The tags creation code was stored in main.go while all the other
database setup code was located in creator.go. This change moves
the function there and also takes the idempotent step of DROPing
the tags table if it exists before trying to create it. This helps
in scenarios where the database is already created and may have
tags left over.