### PR TITLE
Rewrite tsbs_generate_queries to use internal/inputs

### DIFF
--- a/cmd/tsbs_generate_queries/main.go
+++ b/cmd/tsbs_generate_queries/main.go
@@ -3,24 +3,13 @@
 package main
 
 import (
-	"bufio"
-	"encoding/gob"
 	"flag"
 	"fmt"
-	"log"
-	"math/rand"
 	"os"
-	"sort"
-	"time"
 
-	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/cassandra"
-	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/clickhouse"
-	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx"
-	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/mongo"
-	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/siridb"
-	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/timescaledb"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
+	"github.com/timescale/tsbs/internal/inputs"
 )
 
 var useCaseMatrix = map[string]map[string]utils.QueryFillerMaker{
@@ -43,72 +32,7 @@ var useCaseMatrix = map[string]map[string]utils.QueryFillerMaker{
 	},
 }
 
-const defaultWriteSize = 4 << 20 // 4 MB
-
-// Program option vars:
-var (
-	fatal = log.Fatalf
-
-	generator utils.DevopsGenerator
-	filler    utils.QueryFiller
-
-	queryCount int
-	fileName   string
-
-	seed  int64
-	debug int
-
-	timescaleUseJSON       bool
-	timescaleUseTags       bool
-	timescaleUseTimeBucket bool
-
-	clickhouseUseTags bool
-
-	interleavedGenerationGroupID uint
-	interleavedGenerationGroups  uint
-)
-
-func getGenerator(format string, start, end time.Time, scale int) utils.DevopsGenerator {
-	if format == "cassandra" {
-		return cassandra.NewDevops(start, end, scale)
-	} else if format == "clickhouse" {
-		tgen := clickhouse.NewDevops(start, end, scale)
-		tgen.UseTags = clickhouseUseTags
-		return tgen
-	} else if format == "influx" {
-		return influx.NewDevops(start, end, scale)
-	} else if format == "mongo" {
-		return mongo.NewDevops(start, end, scale)
-	} else if format == "mongo-naive" {
-		return mongo.NewNaiveDevops(start, end, scale)
-	} else if format == "siridb" {
-		return siridb.NewDevops(start, end, scale)
-	} else if format == "timescaledb" {
-		tgen := timescaledb.NewDevops(start, end, scale)
-		tgen.UseJSON = timescaleUseJSON
-		tgen.UseTags = timescaleUseTags
-		tgen.UseTimeBucket = timescaleUseTimeBucket
-		return tgen
-	}
-
-	panic(fmt.Sprintf("no devops generator specified for format '%s'", format))
-}
-
-// GetBufferedWriter returns the buffered Writer that should be used for generated output
-func GetBufferedWriter(fileName string) *bufio.Writer {
-	// Prepare output file/STDOUT
-	if len(fileName) > 0 {
-		// Write output to file
-		file, err := os.Create(fileName)
-		if err != nil {
-			fatal("cannot open file for write %s: %v", fileName, err)
-		}
-		return bufio.NewWriterSize(file, defaultWriteSize)
-	}
-
-	// Write output to STDOUT
-	return bufio.NewWriterSize(os.Stdout, defaultWriteSize)
-}
+var config = &inputs.QueryGeneratorConfig{}
 
 // Parse args:
 func init() {
@@ -127,141 +51,23 @@ func init() {
 		}
 	}
 
-	var format string
-	var useCase string
-	var queryType string
-	var scale int
-	var timestampStartStr string
-	var timestampEndStr string
+	config.AddToFlagSet(flag.CommandLine)
 
-	flag.StringVar(&format, "format", "", "Format to emit. (Choices are in the use case matrix.)")
-	flag.StringVar(&useCase, "use-case", "", "Use case to model. (Choices are in the use case matrix.)")
-	flag.StringVar(&queryType, "query-type", "", "Query type. (Choices are in the use case matrix.)")
+	flag.Uint64Var(&config.Limit, "queries", 1000, "Number of queries to generate.")
 
-	flag.IntVar(&scale, "scale", 1, "Scaling variable (must be the equal to the scalevar used for data generation).")
-	flag.IntVar(&queryCount, "queries", 1000, "Number of queries to generate.")
-
-	flag.BoolVar(&timescaleUseJSON, "timescale-use-json", false, "TimescaleDB only: Use separate JSON tags table when querying")
-	flag.BoolVar(&timescaleUseTags, "timescale-use-tags", true, "TimescaleDB only: Use separate tags table when querying")
-	flag.BoolVar(&timescaleUseTimeBucket, "timescale-use-time-bucket", true, "TimescaleDB only: Use time bucket. Set to false to test on native PostgreSQL")
-
-	flag.BoolVar(&clickhouseUseTags, "clickhouse-use-tags", true, "ClickHouse only: Use separate tags table when querying")
-
-	flag.StringVar(&timestampStartStr, "timestamp-start", "2016-01-01T00:00:00Z", "Beginning timestamp (RFC3339).")
-	flag.StringVar(&timestampEndStr, "timestamp-end", "2016-01-02T06:00:00Z", "Ending timestamp (RFC3339).")
-
-	flag.Int64Var(&seed, "seed", 0, "PRNG seed (default, or 0, uses the current timestamp).")
-	flag.IntVar(&debug, "debug", 0, "Debug printing (choices: 0, 1) (default 0).")
-
-	flag.UintVar(&interleavedGenerationGroupID, "interleaved-generation-group-id", 0, "Group (0-indexed) to perform round-robin serialization within. Use this to scale up data generation to multiple processes.")
-	flag.UintVar(&interleavedGenerationGroups, "interleaved-generation-groups", 1, "The number of round-robin serialization groups. Use this to scale up data generation to multiple processes.")
-
-	flag.StringVar(&fileName, "file", "", "File name to write generated queries to")
+	flag.BoolVar(&config.ClickhouseUseTags, "clickhouse-use-tags", true, "ClickHouse only: Use separate tags table when querying")
+	flag.BoolVar(&config.MongoUseNaive, "mongo-use-naive", true, "MongoDB only: Generate queries for the 'naive' data storage format for Mongo")
+	flag.BoolVar(&config.TimescaleUseJSON, "timescale-use-json", false, "TimescaleDB only: Use separate JSON tags table when querying")
+	flag.BoolVar(&config.TimescaleUseTags, "timescale-use-tags", true, "TimescaleDB only: Use separate tags table when querying")
+	flag.BoolVar(&config.TimescaleUseTimeBucket, "timescale-use-time-bucket", true, "TimescaleDB only: Use time bucket. Set to false to test on native PostgreSQL")
 
 	flag.Parse()
-
-	if !(interleavedGenerationGroupID < interleavedGenerationGroups) {
-		fatal("incorrect interleaved groups configuration")
-	}
-
-	if _, ok := useCaseMatrix[useCase]; !ok {
-		fatal("invalid use case specifier: '%s'", useCase)
-	}
-
-	if _, ok := useCaseMatrix[useCase][queryType]; !ok {
-		fatal("invalid query type specifier: '%s'", queryType)
-	}
-
-	// the default seed is the current timestamp:
-	if seed == 0 {
-		seed = int64(time.Now().Nanosecond())
-	}
-	fmt.Fprintf(os.Stderr, "using random seed %d\n", seed)
-
-	// Parse timestamps:
-	var err error
-	timestampStart, err := time.Parse(time.RFC3339, timestampStartStr)
-	if err != nil {
-		fatal(err.Error())
-	}
-	timestampStart = timestampStart.UTC()
-	timestampEnd, err := time.Parse(time.RFC3339, timestampEndStr)
-	if err != nil {
-		fatal(err.Error())
-	}
-	timestampEnd = timestampEnd.UTC()
-
-	// Make the query generator:
-	generator = getGenerator(format, timestampStart, timestampEnd, scale)
-	filler = useCaseMatrix[useCase][queryType](generator)
 }
 
 func main() {
-	rand.Seed(seed)
-	// Set up bookkeeping:
-	stats := make(map[string]int64)
-
-	// Get output writer
-	out := GetBufferedWriter(fileName)
-	defer func() {
-		err := out.Flush()
-		if err != nil {
-			fatal(err.Error())
-		}
-	}()
-
-	// Create request instances, serializing them to stdout and collecting
-	// counts for each kind. If applicable, only prints queries that
-	// belong to this interleaved group id:
-	currentInterleavedGroup := uint(0)
-
-	enc := gob.NewEncoder(out)
-	for i := 0; i < queryCount; i++ {
-		q := generator.GenerateEmptyQuery()
-		q = filler.Fill(q)
-
-		if currentInterleavedGroup == interleavedGenerationGroupID {
-			err := enc.Encode(q)
-			if err != nil {
-				fatal("encoder %v", err)
-			}
-			stats[string(q.HumanLabelName())]++
-
-			if debug == 1 {
-				_, err := fmt.Fprintf(os.Stderr, "%s\n", q.HumanLabelName())
-				if err != nil {
-					fatal(err.Error())
-				}
-			} else if debug == 2 {
-				_, err := fmt.Fprintf(os.Stderr, "%s\n", q.HumanDescriptionName())
-				if err != nil {
-					fatal(err.Error())
-				}
-			} else if debug >= 3 {
-				_, err := fmt.Fprintf(os.Stderr, "%s\n", q.String())
-				if err != nil {
-					fatal(err.Error())
-				}
-			}
-		}
-		q.Release()
-
-		currentInterleavedGroup++
-		if currentInterleavedGroup == interleavedGenerationGroups {
-			currentInterleavedGroup = 0
-		}
-	}
-
-	// Print stats:
-	keys := []string{}
-	for k := range stats {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		_, err := fmt.Fprintf(os.Stderr, "%s: %d points\n", k, stats[k])
-		if err != nil {
-			fatal(err.Error())
-		}
+	qg := inputs.NewQueryGenerator(useCaseMatrix)
+	err := qg.Generate(config)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
 	}
 }

--- a/internal/inputs/generator.go
+++ b/internal/inputs/generator.go
@@ -39,13 +39,13 @@ type BaseConfig struct {
 	TimeStart string
 	TimeEnd   string
 
-	Seed    int64
-	Verbose bool
-	File    string
+	Seed  int64
+	Debug int
+	File  string
 }
 
 func (c *BaseConfig) AddToFlagSet(fs *flag.FlagSet) {
-	fs.StringVar(&c.Format, "format", "", fmt.Sprintf("Format to generate. (choices: %s)", strings.Join(ValidFormats(), ", ")))
+	fs.StringVar(&c.Format, "format", "", fmt.Sprintf("Format to generate. (choices: %s)", strings.Join(formats, ", ")))
 	fs.StringVar(&c.Use, "use-case", "", fmt.Sprintf("Use case to generate."))
 	fs.StringVar(&c.File, "file", "", "Write the output to this path")
 
@@ -55,7 +55,7 @@ func (c *BaseConfig) AddToFlagSet(fs *flag.FlagSet) {
 	fs.Uint64Var(&c.Scale, "scale", 1, "Scaling value specific to use case (e.g., devices in 'devops').")
 	fs.Int64Var(&c.Seed, "seed", 0, "PRNG seed (default: 0, which uses the current timestamp)")
 
-	fs.BoolVar(&c.Verbose, "verbose", false, "Show verbose output")
+	fs.IntVar(&c.Debug, "debug", 0, "Control level of debug output")
 }
 
 func (c *BaseConfig) Validate() error {

--- a/internal/inputs/generator_data.go
+++ b/internal/inputs/generator_data.go
@@ -28,19 +28,6 @@ const (
 
 const defaultLogInterval = 10 * time.Second
 
-// validateGroups checks validity of combination groupID and totalGroups
-func validateGroups(groupID, totalGroupsNum uint) error {
-	if totalGroupsNum == 0 {
-		// Need at least one group
-		return fmt.Errorf(errTotalGroupsZero)
-	}
-	if groupID >= totalGroupsNum {
-		// Need reasonable groupID
-		return fmt.Errorf(errInvalidGroupsFmt, groupID, totalGroupsNum)
-	}
-	return nil
-}
-
 // DataGeneratorConfig is the GeneratorConfig that should be used with a
 // DataGenerator. It includes all the fields from a BaseConfig, as well as some
 // options that are specific to generating the data for database write operations,
@@ -53,6 +40,7 @@ type DataGeneratorConfig struct {
 	InterleavedNumGroups uint
 }
 
+// Validate checks that the values of the DataGeneratorConfig are reasonable.
 func (c *DataGeneratorConfig) Validate() error {
 	err := c.BaseConfig.Validate()
 	if err != nil {
@@ -263,7 +251,7 @@ func (g *DataGenerator) getSerializer(sim common.Simulator, format string) (seri
 
 		ret = &serialize.TimescaleDBSerializer{}
 	default:
-		err = fmt.Errorf("unknown format: '%s'", format)
+		err = fmt.Errorf(errUnknownFormatFmt, format)
 	}
 
 	return ret, err

--- a/internal/inputs/generator_data_test.go
+++ b/internal/inputs/generator_data_test.go
@@ -16,49 +16,6 @@ import (
 	"github.com/timescale/tsbs/cmd/tsbs_generate_data/serialize"
 )
 
-func TestValidateGroups(t *testing.T) {
-	cases := []struct {
-		desc        string
-		groupID     uint
-		totalGroups uint
-		errMsg      string
-	}{
-		{
-			desc:        "id < total, no err",
-			groupID:     0,
-			totalGroups: 1,
-		},
-		{
-			desc:        "id = total, should err",
-			groupID:     1,
-			totalGroups: 1,
-			errMsg:      fmt.Sprintf(errInvalidGroupsFmt, 1, 1),
-		},
-		{
-			desc:        "id > total, should err",
-			groupID:     2,
-			totalGroups: 1,
-			errMsg:      fmt.Sprintf(errInvalidGroupsFmt, 2, 1),
-		},
-		{
-			desc:        "total = 0, should err",
-			groupID:     0,
-			totalGroups: 0,
-			errMsg:      errTotalGroupsZero,
-		},
-	}
-	for _, c := range cases {
-		err := validateGroups(c.groupID, c.totalGroups)
-		if c.errMsg == "" && err != nil {
-			t.Errorf("%s: unexpected error: %v", c.desc, err)
-		} else if c.errMsg != "" && err == nil {
-			t.Errorf("%s: unexpected lack of error", c.desc)
-		} else if err != nil && err.Error() != c.errMsg {
-			t.Errorf("%s: incorrect error: got %s want %s", c.desc, err.Error(), c.errMsg)
-		}
-	}
-}
-
 func TestDataGeneratorConfigValidate(t *testing.T) {
 	c := &DataGeneratorConfig{
 		BaseConfig: BaseConfig{

--- a/internal/inputs/generator_queries.go
+++ b/internal/inputs/generator_queries.go
@@ -1,0 +1,272 @@
+package inputs
+
+import (
+	"bufio"
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/cassandra"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/clickhouse"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/mongo"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/siridb"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/timescaledb"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
+)
+
+// Error messages when using a QueryGenerator
+const (
+	ErrInvalidQueryConfig = "invalid config: QueryGenerator needs a QueryGeneratorConfig"
+	ErrEmptyQueryType     = "query type cannot be empty"
+
+	errBadQueryTypeFmt        = "invalid query type for use case '%s': '%s'"
+	errCouldNotDebugFmt       = "could not write debug output: %v"
+	errCouldNotEncodeQueryFmt = "could not encode query: %v"
+	errCouldNotQueryStatsFmt  = "could not output query stats: %v"
+)
+
+// QueryGeneratorConfig is the GeneratorConfig that should be used with a
+// QueryGenerator. It includes all the fields from a BaseConfig, as well as
+// options that are specific to generating the queries to test against a
+// database, such as the query type and individual database options.
+type QueryGeneratorConfig struct {
+	BaseConfig
+	QueryType            string
+	InterleavedGroupID   uint
+	InterleavedNumGroups uint
+
+	// TODO - I think this needs some rethinking, but a simple, elegant solution escapes me right now
+	TimescaleUseJSON       bool
+	TimescaleUseTags       bool
+	TimescaleUseTimeBucket bool
+
+	ClickhouseUseTags bool
+
+	MongoUseNaive bool
+}
+
+// Validate checks that the values of the QueryGeneratorConfig are reasonable.
+func (c *QueryGeneratorConfig) Validate() error {
+	err := c.BaseConfig.Validate()
+	if err != nil {
+		return err
+	}
+
+	if c.QueryType == "" {
+		return fmt.Errorf(ErrEmptyQueryType)
+	}
+
+	err = validateGroups(c.InterleavedGroupID, c.InterleavedNumGroups)
+	return err
+}
+
+func (c *QueryGeneratorConfig) AddToFlagSet(fs *flag.FlagSet) {
+	c.BaseConfig.AddToFlagSet(fs)
+	flag.StringVar(&c.QueryType, "query-type", "", "Query type. (Choices are in the use case matrix.)")
+
+	flag.UintVar(&c.InterleavedGroupID, "interleaved-generation-group-id", 0,
+		"Group (0-indexed) to perform round-robin serialization within. Use this to scale up data generation to multiple processes.")
+	flag.UintVar(&c.InterleavedNumGroups, "interleaved-generation-groups", 1,
+		"The number of round-robin serialization groups. Use this to scale up data generation to multiple processes.")
+
+}
+
+// QueryGenerator is a type of Generator for creating queries to test against a
+// database. The output is specific to the type of database (due to each using
+// different querying techniques, e.g. SQL or REST), but is consumed by TSBS
+// query runners like tsbs_run_queries_timescaledb.
+type QueryGenerator struct {
+	// Out is the writer where data should be written. If nil, it will be
+	// os.Stdout unless File is specified in the GeneratorConfig passed to
+	// Generate.
+	Out io.Writer
+	// DebugOut is where non-generated messages should be written. If nil, it
+	// will be os.Stderr.
+	DebugOut io.Writer
+
+	config        *QueryGeneratorConfig
+	useCaseMatrix map[string]map[string]utils.QueryFillerMaker
+	tsStart       time.Time
+	tsEnd         time.Time
+
+	// bufOut represents the buffered writer that should actually be passed to
+	// any operations that write out data.
+	bufOut *bufio.Writer
+}
+
+// NewQueryGenerator returns a QueryGenerator that is set up to work with a given
+// useCaseMatrix, which tells it how to generate the given query type for a use
+// case.
+func NewQueryGenerator(useCaseMatrix map[string]map[string]utils.QueryFillerMaker) *QueryGenerator {
+	return &QueryGenerator{
+		useCaseMatrix: useCaseMatrix,
+	}
+}
+
+func (g *QueryGenerator) Generate(config GeneratorConfig) error {
+	err := g.init(config)
+	if err != nil {
+		return err
+	}
+
+	useGen, err := g.getUseCaseGenerator(g.config)
+	if err != nil {
+		return err
+	}
+
+	filler := g.useCaseMatrix[g.config.Use][g.config.QueryType](useGen)
+
+	return g.runQueryGeneration(useGen, filler, g.config)
+}
+
+func (g *QueryGenerator) init(config GeneratorConfig) error {
+	if config == nil {
+		return fmt.Errorf(ErrNoConfig)
+	}
+	switch config.(type) {
+	case *QueryGeneratorConfig:
+	default:
+		return fmt.Errorf(ErrInvalidDataConfig)
+	}
+	g.config = config.(*QueryGeneratorConfig)
+
+	err := g.config.Validate()
+	if err != nil {
+		return err
+	}
+
+	if _, ok := g.useCaseMatrix[g.config.Use]; !ok {
+		return fmt.Errorf(errBadUseFmt, g.config.Use)
+	}
+
+	if _, ok := g.useCaseMatrix[g.config.Use][g.config.QueryType]; !ok {
+		return fmt.Errorf(errBadQueryTypeFmt, g.config.Use, g.config.QueryType)
+	}
+
+	g.tsStart, err = ParseUTCTime(g.config.TimeStart)
+	if err != nil {
+		return fmt.Errorf(errCannotParseTimeFmt, g.config.TimeStart, err)
+	}
+	g.tsEnd, err = ParseUTCTime(g.config.TimeEnd)
+	if err != nil {
+		return fmt.Errorf(errCannotParseTimeFmt, g.config.TimeEnd, err)
+	}
+
+	if g.Out == nil {
+		g.Out = os.Stdout
+	}
+	g.bufOut, err = getBufferedWriter(g.config.File, g.Out)
+	if err != nil {
+		return err
+	}
+
+	if g.DebugOut == nil {
+		g.DebugOut = os.Stderr
+	}
+
+	return nil
+}
+
+func (g *QueryGenerator) getUseCaseGenerator(c *QueryGeneratorConfig) (utils.DevopsGenerator, error) {
+	var ret utils.DevopsGenerator
+	scale := int(c.Scale) // TODO: make all the Devops constructors use a uint64
+
+	switch c.Format {
+	case FormatCassandra:
+		ret = cassandra.NewDevops(g.tsStart, g.tsEnd, scale)
+	case FormatClickhouse:
+		temp := clickhouse.NewDevops(g.tsStart, g.tsEnd, scale)
+		temp.UseTags = c.ClickhouseUseTags
+		ret = temp
+	case FormatInflux:
+		ret = influx.NewDevops(g.tsStart, g.tsEnd, scale)
+	case FormatMongo:
+		if c.MongoUseNaive {
+			ret = mongo.NewNaiveDevops(g.tsStart, g.tsEnd, scale)
+		} else {
+			ret = mongo.NewDevops(g.tsStart, g.tsEnd, scale)
+		}
+	case FormatSiriDB:
+		ret = siridb.NewDevops(g.tsStart, g.tsEnd, scale)
+	case FormatTimescaleDB:
+		temp := timescaledb.NewDevops(g.tsStart, g.tsEnd, scale)
+		temp.UseJSON = c.TimescaleUseJSON
+		temp.UseTags = c.TimescaleUseTags
+		temp.UseTimeBucket = c.TimescaleUseTimeBucket
+		ret = temp
+	default:
+		return nil, fmt.Errorf(errUnknownFormatFmt, c.Format)
+	}
+	return ret, nil
+}
+
+func (g *QueryGenerator) runQueryGeneration(useGen utils.DevopsGenerator, filler utils.QueryFiller, c *QueryGeneratorConfig) error {
+	stats := make(map[string]int64)
+	currentGroup := uint(0)
+	enc := gob.NewEncoder(g.bufOut)
+	defer g.bufOut.Flush()
+
+	rand.Seed(g.config.Seed)
+	//fmt.Println(g.config.Seed)
+	if g.config.Debug > 0 {
+		_, err := fmt.Fprintf(g.DebugOut, "using random seed %d\n", g.config.Seed)
+		if err != nil {
+			return fmt.Errorf(errCouldNotDebugFmt, err)
+		}
+	}
+
+	for i := 0; i < int(c.Limit); i++ {
+		q := useGen.GenerateEmptyQuery()
+		q = filler.Fill(q)
+
+		if currentGroup == c.InterleavedGroupID {
+			err := enc.Encode(q)
+			if err != nil {
+				return fmt.Errorf(errCouldNotEncodeQueryFmt, err)
+			}
+			stats[string(q.HumanLabelName())]++
+
+			if c.Debug > 0 {
+				var debugMsg string
+				if c.Debug == 1 {
+					debugMsg = string(q.HumanLabelName())
+				} else if c.Debug == 2 {
+					debugMsg = string(q.HumanDescriptionName())
+				} else if c.Debug >= 3 {
+					debugMsg = q.String()
+				}
+
+				_, err = fmt.Fprintf(g.DebugOut, debugMsg+"\n")
+				if err != nil {
+					return fmt.Errorf(errCouldNotDebugFmt, err)
+				}
+			}
+		}
+		q.Release()
+
+		currentGroup++
+		if currentGroup == c.InterleavedNumGroups {
+			currentGroup = 0
+		}
+	}
+
+	// Print stats:
+	keys := []string{}
+	for k := range stats {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		_, err := fmt.Fprintf(g.DebugOut, "%s: %d points\n", k, stats[k])
+		if err != nil {
+			return fmt.Errorf(errCouldNotQueryStatsFmt, err)
+		}
+	}
+	return nil
+}

--- a/internal/inputs/generator_queries_test.go
+++ b/internal/inputs/generator_queries_test.go
@@ -1,0 +1,532 @@
+package inputs
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/cassandra"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/clickhouse"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/mongo"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/siridb"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/timescaledb"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
+	"github.com/timescale/tsbs/query"
+)
+
+func TestQueryGeneratorConfigValidate(t *testing.T) {
+	c := &QueryGeneratorConfig{
+		BaseConfig: BaseConfig{
+			Seed:   123,
+			Format: FormatTimescaleDB,
+			Use:    useCaseDevops,
+			Scale:  10,
+		},
+		QueryType:            "foo",
+		InterleavedGroupID:   0,
+		InterleavedNumGroups: 1,
+	}
+
+	// Test base validation
+	err := c.Validate()
+	if err != nil {
+		t.Errorf("unexpected error for correct config: %v", err)
+	}
+
+	c.Format = "bad format"
+	err = c.Validate()
+	if err == nil {
+		t.Errorf("unexpected lack of error for bad format")
+	}
+	c.Format = FormatTimescaleDB
+
+	// Test QueryType validation
+	c.QueryType = ""
+	err = c.Validate()
+	if err == nil {
+		t.Errorf("unexpected lack of error for empty query type")
+	}
+	c.QueryType = "foo"
+
+	// Test groups validation
+	c.InterleavedNumGroups = 0
+	err = c.Validate()
+	if err == nil {
+		t.Errorf("unexpected lack of error for 0 groups")
+	} else if got := err.Error(); got != errTotalGroupsZero {
+		t.Errorf("incorrect error for 0 groups: got\n%s\nwant\n%s", got, errTotalGroupsZero)
+	}
+	c.InterleavedNumGroups = 1
+
+	c.InterleavedGroupID = 2
+	err = c.Validate()
+	if err == nil {
+		t.Errorf("unexpected lack of error for group id > num groups")
+	} else {
+		want := fmt.Sprintf(errInvalidGroupsFmt, 2, 1)
+		if got := err.Error(); got != want {
+			t.Errorf("incorrect error for group id > num groups: got\n%s\nwant\n%s", got, want)
+		}
+	}
+}
+
+func TestNewQueryGenerator(t *testing.T) {
+	m := map[string]map[string]utils.QueryFillerMaker{
+		"foo": {
+			"bar": nil,
+			"baz": nil,
+		},
+		"bar": {
+			"baz": nil,
+		},
+	}
+	g := NewQueryGenerator(m)
+	if !reflect.DeepEqual(g.useCaseMatrix, m) {
+		t.Errorf("useCaseMatrix not properly set")
+	}
+}
+
+func TestQueryGeneratorInit(t *testing.T) {
+	const okQueryType = "single-groupby-1-1-1"
+	g := &QueryGenerator{
+		useCaseMatrix: map[string]map[string]utils.QueryFillerMaker{
+			useCaseDevops: {
+				okQueryType: nil,
+			},
+		},
+	}
+	// Test that empty config fails
+	err := g.init(nil)
+	if err == nil {
+		t.Errorf("unexpected lack of error with empty config")
+	} else if got := err.Error(); got != ErrNoConfig {
+		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, ErrNoConfig)
+	}
+
+	// Test that wrong type of config fails
+	err = g.init(&BaseConfig{})
+	if err == nil {
+		t.Errorf("unexpected lack of error with invalid config")
+	} else if got := err.Error(); got != ErrInvalidDataConfig {
+		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, ErrInvalidDataConfig)
+	}
+
+	// Test that empty, invalid config fails
+	err = g.init(&QueryGeneratorConfig{})
+	if err == nil {
+		t.Errorf("unexpected lack of error with empty QueryGeneratorConfig")
+	}
+
+	c := &QueryGeneratorConfig{
+		BaseConfig: BaseConfig{
+			Format: FormatTimescaleDB,
+			Use:    useCaseCPUOnly, // not in the useCaseMatrix
+			Scale:  1,
+		},
+		QueryType:            "unknown query type",
+		InterleavedNumGroups: 1,
+	}
+
+	// Test use case not in matrix
+	err = g.init(c)
+	want := fmt.Sprintf(errBadUseFmt, useCaseCPUOnly)
+	if err == nil {
+		t.Errorf("unexpected lack of error with bad use case")
+	} else if got := err.Error(); got != want {
+		t.Errorf("incorrect error for bad use case:\ngot\n%s\nwant\n%s", got, want)
+	}
+	c.Use = useCaseDevops
+
+	// Test unknown query type
+	err = g.init(c)
+	want = fmt.Sprintf(errBadQueryTypeFmt, useCaseDevops, "unknown query type")
+	if err == nil {
+		t.Errorf("unexpected lack of error with bad query type")
+	} else if got := err.Error(); got != want {
+		t.Errorf("incorrect error for bad query type:\ngot\n%s\nwant\n%s", got, want)
+	}
+	c.QueryType = okQueryType
+
+	const errTimePrefix = "cannot parse time from string"
+
+	// Test incorrect time format for start
+	c.TimeStart = "2006 Jan 2"
+	err = g.init(c)
+	if err == nil {
+		t.Errorf("unexpected lack of error with bad start date")
+	} else if got := err.Error(); !strings.HasPrefix(got, errTimePrefix) {
+		t.Errorf("unexpected error for bad start date: got\n%s", got)
+	}
+	c.TimeStart = defaultTimeStart
+
+	// Test incorrect time format for end
+	c.TimeEnd = "Jan 3rd 2016"
+	err = g.init(c)
+	if err == nil {
+		t.Errorf("unexpected lack of error with bad end date")
+	} else if got := err.Error(); !strings.HasPrefix(got, errTimePrefix) {
+		t.Errorf("unexpected error for bad end date: got\n%s", got)
+	}
+	c.TimeEnd = defaultTimeEnd
+
+	// Test that Out is set to os.Stdout if unset
+	err = g.init(c)
+	if err != nil {
+		t.Errorf("unexpected error when checking Out: got %v", err)
+	} else if g.Out != os.Stdout {
+		t.Errorf("Out not set to Stdout")
+	}
+
+	// Test that Out is same if set
+	var buf bytes.Buffer
+	g.Out = &buf
+	err = g.init(c)
+	if err != nil {
+		t.Errorf("unexpected error when checking Out: got %v", err)
+	} else if g.Out != &buf {
+		t.Errorf("Out not set to explicit io.Writer")
+	}
+
+	// Test that DebugOut is set to os.Stderr if unset
+	err = g.init(c)
+	if err != nil {
+		t.Errorf("unexpected error when checking DebugOut: got %v", err)
+	} else if g.DebugOut != os.Stderr {
+		t.Errorf("DebugOut not set to Stderr")
+	}
+}
+
+func TestGetUseCaseGenerator(t *testing.T) {
+	const scale = 10
+	tsStart, _ := ParseUTCTime(defaultTimeStart)
+	tsEnd, _ := ParseUTCTime(defaultTimeEnd)
+	c := &QueryGeneratorConfig{
+		BaseConfig: BaseConfig{
+			Scale: scale,
+		},
+	}
+	g := &QueryGenerator{
+		config:  c,
+		tsStart: tsStart,
+		tsEnd:   tsEnd,
+	}
+	checkType := func(format string, want utils.DevopsGenerator) utils.DevopsGenerator {
+		wantType := reflect.TypeOf(want)
+		c.Format = format
+		useGen, err := g.getUseCaseGenerator(c)
+		if err != nil {
+			t.Errorf("unexpected error with format '%s': %v", format, err)
+		}
+		if got := reflect.TypeOf(useGen); got != wantType {
+			t.Errorf("format '%s' does not give right use case gen: got %v want %v", format, got, wantType)
+		}
+
+		return useGen
+	}
+
+	checkType(FormatCassandra, cassandra.NewDevops(tsStart, tsEnd, scale))
+	checkType(FormatInflux, influx.NewDevops(tsStart, tsEnd, scale))
+	checkType(FormatSiriDB, siridb.NewDevops(tsStart, tsEnd, scale))
+	checkType(FormatMongo, mongo.NewDevops(tsStart, tsEnd, scale))
+	c.MongoUseNaive = true
+	checkType(FormatMongo, mongo.NewNaiveDevops(tsStart, tsEnd, scale))
+
+	useGen := checkType(FormatClickhouse, clickhouse.NewDevops(tsStart, tsEnd, scale))
+	if got := useGen.(*clickhouse.Devops).UseTags; got != c.ClickhouseUseTags {
+		t.Errorf("clickhouse UseTags not set correctly: got %v want %v", got, c.ClickhouseUseTags)
+	}
+
+	c.ClickhouseUseTags = true
+	useGen = checkType(FormatClickhouse, clickhouse.NewDevops(tsStart, tsEnd, scale))
+	if got := useGen.(*clickhouse.Devops).UseTags; got != c.ClickhouseUseTags {
+		t.Errorf("clickhouse UseTags not set correctly: got %v want %v", got, c.ClickhouseUseTags)
+	}
+
+	useGen = checkType(FormatTimescaleDB, timescaledb.NewDevops(tsStart, tsEnd, scale))
+	if got := useGen.(*timescaledb.Devops).UseTags; got != c.TimescaleUseTags {
+		t.Errorf("timescaledb UseTags not set correctly: got %v want %v", got, c.TimescaleUseTags)
+	}
+	if got := useGen.(*timescaledb.Devops).UseJSON; got != c.TimescaleUseJSON {
+		t.Errorf("timescaledb UseJSON not set correctly: got %v want %v", got, c.TimescaleUseJSON)
+	}
+	if got := useGen.(*timescaledb.Devops).UseTimeBucket; got != c.TimescaleUseTimeBucket {
+		t.Errorf("timescaledb UseTimeBucket not set correctly: got %v want %v", got, c.TimescaleUseTimeBucket)
+	}
+
+	c.TimescaleUseJSON = true
+	c.TimescaleUseTags = true
+	c.TimescaleUseTimeBucket = true
+	useGen = checkType(FormatTimescaleDB, timescaledb.NewDevops(tsStart, tsEnd, scale))
+	if got := useGen.(*timescaledb.Devops).UseTags; got != c.TimescaleUseTags {
+		t.Errorf("timescaledb UseTags not set correctly: got %v want %v", got, c.TimescaleUseTags)
+	}
+	if got := useGen.(*timescaledb.Devops).UseJSON; got != c.TimescaleUseJSON {
+		t.Errorf("timescaledb UseJSON not set correctly: got %v want %v", got, c.TimescaleUseJSON)
+	}
+	if got := useGen.(*timescaledb.Devops).UseTimeBucket; got != c.TimescaleUseTimeBucket {
+		t.Errorf("timescaledb UseTimeBucket not set correctly: got %v want %v", got, c.TimescaleUseTimeBucket)
+	}
+
+	// Test error condition
+	c.Format = "bad format"
+	useGen, err := g.getUseCaseGenerator(c)
+	if err == nil {
+		t.Errorf("unexpected lack of error for bad format")
+	} else if got := err.Error(); got != fmt.Sprintf(errUnknownFormatFmt, c.Format) {
+		t.Errorf("incorrect error:\ngot\n%s\nwant\n%s", got, fmt.Sprintf(errUnknownFormatFmt, c.Format))
+	} else if useGen != nil {
+		t.Errorf("useGen was not nil")
+	}
+}
+
+// Decoded previously
+var wantQueries = []query.TimescaleDB{
+	{
+		Hypertable:       []byte("cpu"),
+		HumanLabel:       []byte("TimescaleDB 1 cpu metric(s), random    1 hosts, random 1h0m0s by 1m"),
+		HumanDescription: []byte("TimescaleDB 1 cpu metric(s), random    1 hosts, random 1h0m0s by 1m: 2016-01-01T02:17:08Z"),
+		SqlQuery: []byte(`SELECT time_bucket('60 seconds', time) AS minute,
+        max(usage_user) as max_usage_user
+        FROM cpu
+        WHERE tags_id IN (SELECT id FROM tags WHERE hostname IN ('host_9')) AND time >= '2016-01-01 02:17:08.646325 +0000' AND time < '2016-01-01 03:17:08.646325 +0000'
+        GROUP BY minute ORDER BY minute ASC`),
+	},
+	{
+		Hypertable:       []byte("cpu"),
+		HumanLabel:       []byte("TimescaleDB 1 cpu metric(s), random    1 hosts, random 1h0m0s by 1m"),
+		HumanDescription: []byte("TimescaleDB 1 cpu metric(s), random    1 hosts, random 1h0m0s by 1m: 2016-01-01T14:03:26Z"),
+		SqlQuery: []byte(`SELECT time_bucket('60 seconds', time) AS minute,
+        max(usage_user) as max_usage_user
+        FROM cpu
+        WHERE tags_id IN (SELECT id FROM tags WHERE hostname IN ('host_5')) AND time >= '2016-01-01 14:03:26.894865 +0000' AND time < '2016-01-01 15:03:26.894865 +0000'
+        GROUP BY minute ORDER BY minute ASC`),
+	},
+	{
+		Hypertable:       []byte("cpu"),
+		HumanLabel:       []byte("TimescaleDB 1 cpu metric(s), random    1 hosts, random 1h0m0s by 1m"),
+		HumanDescription: []byte("TimescaleDB 1 cpu metric(s), random    1 hosts, random 1h0m0s by 1m: 2016-01-01T09:11:43Z"),
+		SqlQuery: []byte(`SELECT time_bucket('60 seconds', time) AS minute,
+        max(usage_user) as max_usage_user
+        FROM cpu
+        WHERE tags_id IN (SELECT id FROM tags WHERE hostname IN ('host_9')) AND time >= '2016-01-01 09:11:43.311177 +0000' AND time < '2016-01-01 10:11:43.311177 +0000'
+        GROUP BY minute ORDER BY minute ASC`),
+	},
+}
+
+func getTestConfigAndGenerator() (*QueryGeneratorConfig, *QueryGenerator) {
+	const scale = 10
+	tsStart, _ := ParseUTCTime(defaultTimeStart)
+	tsEnd, _ := ParseUTCTime(defaultTimeEnd)
+	tsEnd = tsEnd.Add(time.Second)
+	c := &QueryGeneratorConfig{
+		BaseConfig: BaseConfig{
+			Format:    FormatTimescaleDB,
+			Use:       useCaseCPUOnly,
+			Scale:     scale,
+			TimeStart: defaultTimeStart,
+			TimeEnd:   strings.Replace(defaultTimeEnd, ":00Z", ":01Z", 1),
+			Limit:     3,
+			Seed:      123,
+		},
+		QueryType:              "single-groupby-1-1-1",
+		TimescaleUseTimeBucket: true,
+		TimescaleUseTags:       true,
+		InterleavedNumGroups:   1,
+	}
+	g := &QueryGenerator{
+		useCaseMatrix: map[string]map[string]utils.QueryFillerMaker{
+			useCaseCPUOnly: {
+				"single-groupby-1-1-1": devops.NewSingleGroupby(1, 1, 1),
+			},
+		},
+		config:   c,
+		tsStart:  tsStart,
+		tsEnd:    tsEnd,
+		DebugOut: os.Stderr,
+	}
+
+	return c, g
+}
+
+func checkGeneratedOutput(t *testing.T, buf *bytes.Buffer) {
+	r := bufio.NewReader(buf)
+	decoder := gob.NewDecoder(r)
+	i := 0
+	for {
+		var q query.TimescaleDB
+		err := decoder.Decode(&q)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("unexpected error while decoding: got %v", err)
+		}
+		want := string(wantQueries[i].SqlQuery)
+		if got := string(q.SqlQuery); got != want {
+			t.Errorf("incorrect query:\ngot\n%s\nwant\n%s", got, want)
+		}
+		i++
+	}
+	if i != len(wantQueries) {
+		t.Errorf("incorrect number of queries: got %d want %d", i, len(wantQueries))
+	}
+}
+
+func TestQueryGeneratorRunQueryGeneration(t *testing.T) {
+	seedLine := "using random seed 123"
+	summaryLine := "TimescaleDB 1 cpu metric(s), random    1 hosts, random 1h0m0s by 1m: 3 points"
+	cases := []struct {
+		level     int
+		wantDebug []string
+	}{
+		{
+			level:     0,
+			wantDebug: []string{summaryLine},
+		},
+		{
+			level: 1,
+			wantDebug: []string{
+				seedLine,
+				string(wantQueries[0].HumanLabelName()),
+				string(wantQueries[1].HumanLabelName()),
+				string(wantQueries[2].HumanLabelName()),
+				summaryLine,
+			},
+		},
+		{
+			level: 2,
+			wantDebug: []string{
+				seedLine,
+				string(wantQueries[0].HumanDescriptionName()),
+				string(wantQueries[1].HumanDescriptionName()),
+				string(wantQueries[2].HumanDescriptionName()),
+				summaryLine,
+			},
+		},
+		{
+			level: 3,
+			wantDebug: []string{
+				seedLine,
+				wantQueries[0].String(),
+				wantQueries[1].String(),
+				wantQueries[2].String(),
+				summaryLine,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		config, g := getTestConfigAndGenerator()
+		config.Debug = c.level
+		var buf bytes.Buffer
+		g.bufOut = bufio.NewWriter(&buf)
+		var debug bytes.Buffer
+		g.DebugOut = &debug
+
+		useGen, err := g.getUseCaseGenerator(config)
+		if err != nil {
+			t.Fatalf("could not get use case gen: %v", err)
+		}
+		filler := g.useCaseMatrix[config.Use][config.QueryType](useGen)
+
+		err = g.runQueryGeneration(useGen, filler, config)
+		if err != nil {
+			t.Errorf("unexpected error: got %v", err)
+		}
+
+		checkGeneratedOutput(t, &buf)
+
+		// Check that the proper debug output was written
+		wantDebug := strings.TrimSpace(strings.Join(c.wantDebug, "\n"))
+		if got := strings.TrimSpace(debug.String()); got != wantDebug {
+			t.Errorf("incorrect line for debug level %d:\ngot\n%s\nwant\n%s", c.level, got, wantDebug)
+		}
+	}
+}
+
+type badWriter struct {
+	when  int
+	count int
+}
+
+func (w *badWriter) Write(p []byte) (int, error) {
+	if w.count >= w.when {
+		return 0, fmt.Errorf("error writing")
+	}
+	w.count++
+	return len(p), nil
+}
+
+func TestQueryGeneratorRunQueryGenerationErrors(t *testing.T) {
+	c, g := getTestConfigAndGenerator()
+	var buf bytes.Buffer
+	g.bufOut = bufio.NewWriter(&buf)
+
+	useGen, err := g.getUseCaseGenerator(c)
+	if err != nil {
+		t.Fatalf("could not get use case gen: %v", err)
+	}
+	filler := g.useCaseMatrix[c.Use][c.QueryType](useGen)
+
+	checkErr := func(want string) {
+		err = g.runQueryGeneration(useGen, filler, c)
+		if err == nil {
+			t.Errorf("unexpected lack of error")
+		} else if got := err.Error(); !strings.HasPrefix(got, want) {
+			t.Errorf("incorrect error for output query stats:\ngot\n%s\nwant\n%s", got, want)
+		}
+	}
+
+	// Test error condition when printing stats
+	g.DebugOut = &badWriter{}
+	want := fmt.Sprintf(errCouldNotQueryStatsFmt, "error writing")
+	checkErr(want)
+
+	// Test error condition when printing seed
+	c.Debug = 1
+	want = fmt.Sprintf(errCouldNotDebugFmt, "error writing")
+	checkErr(want)
+
+	// Test error condition inside loop; first debug is success
+	g.DebugOut = &badWriter{when: 1}
+	checkErr(want)
+
+	g.DebugOut = &badWriter{when: 2}
+	checkErr(want)
+
+	// Test error on encoding
+	g.DebugOut = &badWriter{when: 10000}
+	g.bufOut = bufio.NewWriterSize(&badWriter{}, 8) // small buffer forces it to write to underlying
+	want = fmt.Sprintf(errCouldNotEncodeQueryFmt, "error writing")
+	checkErr(want)
+}
+
+func TestQueryGeneratorGenerate(t *testing.T) {
+	g := &QueryGenerator{}
+
+	// Test that an invalid config fails
+	c := &QueryGeneratorConfig{}
+	err := g.Generate(c)
+	if err == nil {
+		t.Errorf("unexpected lack of error with empty QueryGeneratorConfig")
+	}
+
+	c, g = getTestConfigAndGenerator()
+	var buf bytes.Buffer
+	g.Out = &buf
+	g.DebugOut = ioutil.Discard
+	err = g.Generate(c)
+	if err != nil {
+		t.Errorf("unexpected error when generating: got %v", err)
+	}
+	checkGeneratedOutput(t, &buf)
+}

--- a/internal/inputs/utils.go
+++ b/internal/inputs/utils.go
@@ -21,6 +21,8 @@ const (
 const (
 	defaultTimeStart = "2016-01-01T00:00:00Z"
 	defaultTimeEnd   = "2016-01-02T00:00:00Z"
+
+	errUnknownFormatFmt = "unknown format: '%s'"
 )
 
 var formats = []string{
@@ -30,10 +32,6 @@ var formats = []string{
 	FormatMongo,
 	FormatSiriDB,
 	FormatTimescaleDB,
-}
-
-func ValidFormats() []string {
-	return append([]string{}, formats...)
 }
 
 func isIn(s string, arr []string) bool {
@@ -80,4 +78,17 @@ func getBufferedWriter(filename string, fallback io.Writer) (*bufio.Writer, erro
 	}
 
 	return bufio.NewWriterSize(fallback, defaultWriteSize), nil
+}
+
+// validateGroups checks validity of combination groupID and totalGroups
+func validateGroups(groupID, totalGroupsNum uint) error {
+	if totalGroupsNum == 0 {
+		// Need at least one group
+		return fmt.Errorf(errTotalGroupsZero)
+	}
+	if groupID >= totalGroupsNum {
+		// Need reasonable groupID
+		return fmt.Errorf(errInvalidGroupsFmt, groupID, totalGroupsNum)
+	}
+	return nil
 }

--- a/internal/inputs/utils_test.go
+++ b/internal/inputs/utils_test.go
@@ -1,6 +1,7 @@
 package inputs
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -53,5 +54,48 @@ func TestParseUTCTime(t *testing.T) {
 	_, err = ParseUTCTime(incorrectTimeStr)
 	if err == nil {
 		t.Errorf("unexpected lack of error")
+	}
+}
+
+func TestValidateGroups(t *testing.T) {
+	cases := []struct {
+		desc        string
+		groupID     uint
+		totalGroups uint
+		errMsg      string
+	}{
+		{
+			desc:        "id < total, no err",
+			groupID:     0,
+			totalGroups: 1,
+		},
+		{
+			desc:        "id = total, should err",
+			groupID:     1,
+			totalGroups: 1,
+			errMsg:      fmt.Sprintf(errInvalidGroupsFmt, 1, 1),
+		},
+		{
+			desc:        "id > total, should err",
+			groupID:     2,
+			totalGroups: 1,
+			errMsg:      fmt.Sprintf(errInvalidGroupsFmt, 2, 1),
+		},
+		{
+			desc:        "total = 0, should err",
+			groupID:     0,
+			totalGroups: 0,
+			errMsg:      errTotalGroupsZero,
+		},
+	}
+	for _, c := range cases {
+		err := validateGroups(c.groupID, c.totalGroups)
+		if c.errMsg == "" && err != nil {
+			t.Errorf("%s: unexpected error: %v", c.desc, err)
+		} else if c.errMsg != "" && err == nil {
+			t.Errorf("%s: unexpected lack of error", c.desc)
+		} else if err != nil && err.Error() != c.errMsg {
+			t.Errorf("%s: incorrect error: got %s want %s", c.desc, err.Error(), c.errMsg)
+		}
 	}
 }


### PR DESCRIPTION
This PR continues on the work in the previous one that changed
tsbs_generate_data to use a new internal/inputs package. This PR
adds a new Generator type for query generation called QueryGenerator.

Now that these two generators share some common code, they both
become much more robust and easier to test and manage. Previously
tsbs_generate_queries had no test coverage, but with this change it
will actually have quite high coverage.

There are still some rough spots with this refactor. In particular,
how the useCaseMatrix is handled needs some more thought, especially
if we are going to add more use cases going forward. Additionally,
the database specific flags like TimescaleUseJSON could probably
be handled in a cleaner way as well.