### PR TITLE
Fix additional tags to work with pgx

### DIFF
--- a/cmd/tsbs_load_timescaledb/process.go
+++ b/cmd/tsbs_load_timescaledb/process.go
@@ -37,16 +37,12 @@ func newSyncCSI() *syncCSI {
 // therefore all workers need to know about the same map from hostname -> tags_id
 var globalSyncCSI = newSyncCSI()
 
-func subsystemTagsToJSON(tags []string) string {
-	json := "{"
-	for i, t := range tags {
+func subsystemTagsToJSON(tags []string) map[string]interface{} {
+	json := map[string]interface{}{}
+	for _, t := range tags {
 		args := strings.Split(t, "=")
-		if i > 0 {
-			json += ","
-		}
-		json += fmt.Sprintf("\"%s\": \"%s\"", args[0], args[1])
+		json[args[0]] = args[1]
 	}
-	json += "}"
 	return json
 }
 


### PR DESCRIPTION
Unlike libpq/sqlx, pgx expects JSON/B fields in the copy command to
be in the 'native' format, which is a map[string]interface{}, not a
string in valid JSON format. Without this change, the copy would
fail with "ERROR: unsupported jsonb version number 123".

Fixes #68