### PR TITLE
Make statProcessor an interface and create tests for BencRunner

### DIFF
--- a/query/benchmarker_test.go
+++ b/query/benchmarker_test.go
@@ -1,6 +1,9 @@
 package query
 
 import (
+	"io/ioutil"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -51,4 +54,264 @@ func TestProcessorHandler(t *testing.T) {
 	if p1.count+p2.count != qLimit {
 		t.Errorf("total queries wrong: want %d got %d", qLimit, p1.count+p2.count)
 	}
+}
+
+func TestProcessorHandlerPreWarm(t *testing.T) {
+	qLimit := 17
+	p1Num := 0
+	p2Num := 5
+
+	p1 := &testProcessor{}
+	p2 := &testProcessor{}
+	b := &BenchmarkRunner{}
+	b.scanner = newScanner(&b.limit)
+	spArgs := &statProcessorArgs{
+		limit:          &b.limit,
+		prewarmQueries: true,
+	}
+	b.sp = newStatProcessor(spArgs)
+	b.ch = make(chan Query, 2)
+	var wg sync.WaitGroup
+	qPool := &testQueryPool
+	wg.Add(2)
+	go b.processorHandler(&wg, qPool, p1, 0)
+	go b.processorHandler(&wg, qPool, p2, 5)
+	for i := 0; i < qLimit; i++ {
+		q := qPool.Get().(*testQuery)
+		b.ch <- q
+	}
+	close(b.ch)
+	wg.Wait()
+
+	if p1.wNum != p1Num {
+		t.Errorf("p1 Init() not called: want %d got %d", p1Num, p1.wNum)
+	}
+	if p2.wNum != p2Num {
+		t.Errorf("p2 Init() not called: want %d got %d", p2Num, p2.wNum)
+	}
+	if p1.count+p2.count != 2*qLimit {
+		t.Errorf("total queries wrong: want %d got %d", 2*qLimit, p1.count+p2.count)
+	}
+}
+func TestBenchmarkRunnerGetBufferedReaderPanicOnMissingFile(t *testing.T) {
+	dumbFileName := "some-random-file-that-should-not-exist"
+	_, err := os.Stat(dumbFileName)
+	if os.IsExist(err) {
+		t.Fatalf("file '%s' should not exist", dumbFileName)
+	}
+	b := &BenchmarkRunner{
+		fileName: dumbFileName,
+	}
+	defer func() {
+		if r := recover(); !strings.HasPrefix(r.(string), "cannot open file for read") {
+			t.Error("wrong panic")
+		}
+	}()
+	b.GetBufferedReader()
+	t.Error("the code did not panic")
+}
+
+func TestBenchmarkRunnerGetBufferedReaderCached(t *testing.T) {
+	// SETUP
+	// create temporary empty file to open
+	randomFile, err := ioutil.TempFile("", "temp_file_*")
+	if err != nil {
+		t.Fatalf("Could not create temp file: %v", err)
+	}
+
+	// and a file name for a non-existing file
+	dumbFileName := "some-random-file-that-should-not-exist"
+	_, err = os.Stat(dumbFileName)
+	if os.IsExist(err) {
+		t.Fatalf("File '%s' should not exist", dumbFileName)
+	}
+
+	b := &BenchmarkRunner{
+		fileName: randomFile.Name(),
+	}
+
+	// RUN
+	// first call to existing file
+	// creates a new buffered reader and caches it
+	b.GetBufferedReader()
+
+	//change file name
+	b.fileName = dumbFileName
+
+	// second call should use cached, not open another BuffReader
+	b.GetBufferedReader()
+}
+
+func TestBenchmarkRunnerRunPanicOnNoWorkers(t *testing.T) {
+	runner := &BenchmarkRunner{}
+	defer func() {
+		if r := recover(); r != "must have at least one worker" {
+			t.Error("wrong panic")
+		}
+	}()
+	runner.Run(nil, nil)
+	t.Errorf("the code did not panic")
+}
+
+func TestBenchmarkRunnerGettersAndSetters(t *testing.T) {
+	b := &BenchmarkRunner{}
+	b.SetLimit(1)
+	if b.limit != 1 {
+		t.Errorf("Expected %d, got %d", 1, b.limit)
+	}
+
+	b.printResponses = true
+	if !b.DoPrintResponses() {
+		t.Error("Expected true, got false")
+	}
+	b.debug = 12
+	if b.DebugLevel() != 12 {
+		t.Errorf("Expected 12, got %d", b.DebugLevel())
+	}
+
+	b.dbName = "Some name"
+	if b.DatabaseName() != "Some name" {
+		t.Errorf("Expected 'Some name', got '%s'", b.DatabaseName())
+	}
+}
+func TestBenchmarkRunnerRunPanicOnBurnInBiggerThanLimit(t *testing.T) {
+	limit := uint64(1)
+	runner := &BenchmarkRunner{
+		workers: 1,
+		sp: &defaultStatProcessor{
+			args: &statProcessorArgs{burnIn: limit + 1},
+		},
+	}
+	defer func() {
+		if r := recover(); r != "burn-in is larger than limit" {
+			t.Error("wrong panic")
+		}
+	}()
+	runner.Run(nil, nil)
+	t.Errorf("the code did not panic")
+}
+
+func TestBenchmarkRunnerRunNoQueries(t *testing.T) {
+	// SETUP
+	// ..empty query file
+	fakeQueriesFile, err := ioutil.TempFile("", "fake_queries*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	profFile, err := ioutil.TempFile("", "temp_file_*")
+	if err != nil {
+		t.Fatalf("Could not create temp file: %v", err)
+	}
+
+	spStarted := false
+	sendStatsCalled := false
+	// lock controlls access to spStarted and sendStatsCalled
+	// wg gets Done when sp is closed
+	wg := &sync.WaitGroup{}
+	lock := &sync.Mutex{}
+	sp := mockStatProcessor{
+		args: &statProcessorArgs{},
+		onProcess: func(_ uint) {
+			lock.Lock()
+			spStarted = true
+			lock.Unlock()
+		},
+		onSend: func(_ []*Stat) {
+			lock.Lock()
+			sendStatsCalled = true
+			lock.Unlock()
+		},
+		wg: wg,
+	}
+
+	/* Query execution workers wait to receive a decoded query
+	on a input channel. The scanner reads an input file, decodes
+	the queries	and submits them to the input channel. When EOF
+	reached is reached, the input channel is closed. Benchmarker
+	waits for workers to finish and reports stats. */
+	limit := uint64(1)
+	b := &BenchmarkRunner{
+		workers:    1,
+		limit:      limit,
+		sp:         &sp,
+		fileName:   fakeQueriesFile.Name(),
+		scanner:    newScanner(&limit),
+		memProfile: profFile.Name(),
+	}
+
+	processor := &mockProcessor{}
+	processorsCreated := uint(0)
+	createProcessorFn := func() Processor {
+		lock.Lock()
+		processorsCreated++
+		lock.Unlock()
+		return processor
+	}
+	// no queries => no worker should execute/process a query
+	// no errors expected
+
+	// RUN
+	wg.Add(1)
+	b.Run(&TimescaleDBPool, createProcessorFn)
+	wg.Wait()
+	lock.Lock()
+	// ASSERT
+	if !spStarted {
+		t.Error("stat processor wasn't started")
+	}
+	if processorsCreated != b.workers {
+		t.Errorf("expected %d processors to be created, but %d were", b.workers, processorsCreated)
+	}
+	if !sp.closed {
+		t.Error("stat processor wasn't closed")
+	}
+	if !processor.initCalled {
+		t.Errorf("init of processor wasn't called")
+	}
+	if sendStatsCalled {
+		t.Errorf("send Stats should not have been called. No queries")
+	}
+}
+
+type mockStatProcessor struct {
+	args      *statProcessorArgs
+	onSend    func([]*Stat)
+	onProcess func(uint)
+	closed    bool
+	wg        *sync.WaitGroup
+}
+
+func (m *mockStatProcessor) getArgs() *statProcessorArgs {
+	return m.args
+}
+func (m *mockStatProcessor) send(stats []*Stat) {
+	if m.onSend != nil {
+		m.onSend(stats)
+	}
+}
+func (m *mockStatProcessor) sendWarm(stats []*Stat) {
+	if m.onSend != nil {
+		m.onSend(stats)
+	}
+}
+func (m *mockStatProcessor) process(workers uint) {
+	if m.onProcess != nil {
+		m.onProcess(workers)
+	}
+}
+func (m *mockStatProcessor) CloseAndWait() {
+	m.closed = true
+	m.wg.Done()
+}
+
+type mockProcessor struct {
+	processRes []*Stat
+	processErr error
+	initCalled bool
+}
+
+func (mp *mockProcessor) Init(workerNum int) { mp.initCalled = true }
+func (mp *mockProcessor) ProcessQuery(q Query, isWarm bool) ([]*Stat, error) {
+	return mp.processRes, mp.processErr
 }

--- a/query/stat_processor.go
+++ b/query/stat_processor.go
@@ -8,16 +8,40 @@ import (
 )
 
 // statProcessor is used to collect, analyze, and print query execution statistics.
-type statProcessor struct {
-	prewarmQueries bool       // PrewarmQueries tells the StatProcessor whether we're running each query twice to prewarm the cache
-	c              chan *Stat // c is the channel for Stats to be sent for processing
-	limit          *uint64    // limit is the number of statistics to analyze before stopping
-	burnIn         uint64     // burnIn is the number of statistics to ignore before analyzing
-	printInterval  uint64     // printInterval is how often print intermediate stats (number of queries)
-	wg             sync.WaitGroup
+type statProcessor interface {
+	getArgs() *statProcessorArgs
+	send(stats []*Stat)
+	sendWarm(stats []*Stat)
+	process(workers uint)
+	CloseAndWait()
 }
 
-func (sp *statProcessor) sendStats(stats []*Stat) {
+type statProcessorArgs struct {
+	prewarmQueries bool    // PrewarmQueries tells the StatProcessor whether we're running each query twice to prewarm the cache
+	limit          *uint64 // limit is the number of statistics to analyze before stopping
+	burnIn         uint64  // burnIn is the number of statistics to ignore before analyzing
+	printInterval  uint64  // printInterval is how often print intermediate stats (number of queries)
+}
+
+// statProcessor is used to collect, analyze, and print query execution statistics.
+type defaultStatProcessor struct {
+	args *statProcessorArgs
+	wg   sync.WaitGroup
+	c    chan *Stat // c is the channel for Stats to be sent for processing
+}
+
+func newStatProcessor(args *statProcessorArgs) statProcessor {
+	if args == nil {
+		panic("Stat Processor needs args")
+	}
+	return &defaultStatProcessor{args: args}
+}
+
+func (sp *defaultStatProcessor) getArgs() *statProcessorArgs {
+	return sp.args
+}
+
+func (sp *defaultStatProcessor) send(stats []*Stat) {
 	if stats == nil {
 		return
 	}
@@ -27,7 +51,7 @@ func (sp *statProcessor) sendStats(stats []*Stat) {
 	}
 }
 
-func (sp *statProcessor) sendStatsWarm(stats []*Stat) {
+func (sp *defaultStatProcessor) sendWarm(stats []*Stat) {
 	if stats == nil {
 		return
 	}
@@ -35,38 +59,38 @@ func (sp *statProcessor) sendStatsWarm(stats []*Stat) {
 	for _, s := range stats {
 		s.isWarm = true
 	}
-	sp.sendStats(stats)
+	sp.send(stats)
 }
 
 // process collects latency results, aggregating them into summary
 // statistics. Optionally, they are printed to stderr at regular intervals.
-func (sp *statProcessor) process(workers uint) {
+func (sp *defaultStatProcessor) process(workers uint) {
 	sp.c = make(chan *Stat, workers)
 	sp.wg.Add(1)
 	const allQueriesLabel = labelAllQueries
 	statMapping := map[string]*statGroup{
-		allQueriesLabel: newStatGroup(*sp.limit),
+		allQueriesLabel: newStatGroup(*sp.args.limit),
 	}
 	// Only needed when differentiating between cold & warm
-	if sp.prewarmQueries {
-		statMapping[labelColdQueries] = newStatGroup(*sp.limit)
-		statMapping[labelWarmQueries] = newStatGroup(*sp.limit)
+	if sp.args.prewarmQueries {
+		statMapping[labelColdQueries] = newStatGroup(*sp.args.limit)
+		statMapping[labelWarmQueries] = newStatGroup(*sp.args.limit)
 	}
 
 	i := uint64(0)
 	for stat := range sp.c {
-		if i < sp.burnIn {
+		if i < sp.args.burnIn {
 			i++
 			statPool.Put(stat)
 			continue
-		} else if i == sp.burnIn && sp.burnIn > 0 {
-			_, err := fmt.Fprintf(os.Stderr, "burn-in complete after %d queries with %d workers\n", sp.burnIn, workers)
+		} else if i == sp.args.burnIn && sp.args.burnIn > 0 {
+			_, err := fmt.Fprintf(os.Stderr, "burn-in complete after %d queries with %d workers\n", sp.args.burnIn, workers)
 			if err != nil {
 				log.Fatal(err)
 			}
 		}
 		if _, ok := statMapping[string(stat.label)]; !ok {
-			statMapping[string(stat.label)] = newStatGroup(*sp.limit)
+			statMapping[string(stat.label)] = newStatGroup(*sp.args.limit)
 		}
 
 		statMapping[string(stat.label)].push(stat.value)
@@ -75,7 +99,7 @@ func (sp *statProcessor) process(workers uint) {
 			statMapping[allQueriesLabel].push(stat.value)
 
 			// Only needed when differentiating between cold & warm
-			if sp.prewarmQueries {
+			if sp.args.prewarmQueries {
 				if stat.isWarm {
 					statMapping[labelWarmQueries].push(stat.value)
 				} else {
@@ -86,7 +110,7 @@ func (sp *statProcessor) process(workers uint) {
 			// If we're prewarming queries (i.e., running them twice in a row),
 			// only increment the counter for the first (cold) query. Otherwise,
 			// increment for every query.
-			if !sp.prewarmQueries || !stat.isWarm {
+			if !sp.args.prewarmQueries || !stat.isWarm {
 				i++
 			}
 		}
@@ -94,8 +118,8 @@ func (sp *statProcessor) process(workers uint) {
 		statPool.Put(stat)
 
 		// print stats to stderr (if printInterval is greater than zero):
-		if sp.printInterval > 0 && i > 0 && i%sp.printInterval == 0 && (i < *sp.limit || *sp.limit == 0) {
-			_, err := fmt.Fprintf(os.Stderr, "after %d queries with %d workers:\n", i-sp.burnIn, workers)
+		if sp.args.printInterval > 0 && i > 0 && i%sp.args.printInterval == 0 && (i < *sp.args.limit || *sp.args.limit == 0) {
+			_, err := fmt.Fprintf(os.Stderr, "after %d queries with %d workers:\n", i-sp.args.burnIn, workers)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -111,7 +135,7 @@ func (sp *statProcessor) process(workers uint) {
 	}
 
 	// the final stats output goes to stdout:
-	_, err := fmt.Printf("run complete after %d queries with %d workers:\n", i-sp.burnIn, workers)
+	_, err := fmt.Printf("run complete after %d queries with %d workers:\n", i-sp.args.burnIn, workers)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -123,7 +147,7 @@ func (sp *statProcessor) process(workers uint) {
 }
 
 // CloseAndWait closes the stats channel and blocks until the StatProcessor has finished all the stats on its channel.
-func (sp *statProcessor) CloseAndWait() {
+func (sp *defaultStatProcessor) CloseAndWait() {
 	close(sp.c)
 	sp.wg.Wait()
 }

--- a/query/stat_processor_test.go
+++ b/query/stat_processor_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestStatProcessorSendStats(t *testing.T) {
+func TestStatProcessorSend(t *testing.T) {
 	s := GetStat()
 	s.isWarm = true
 	statPool.Put(s)
@@ -14,9 +14,9 @@ func TestStatProcessorSendStats(t *testing.T) {
 		t.Errorf("initial stat came back warm unexpectedly")
 	}
 	s.value = 10.1
-	sp := &statProcessor{}
+	sp := &defaultStatProcessor{}
 	sp.c = make(chan *Stat, 2)
-	sp.sendStats([]*Stat{s, s})
+	sp.send([]*Stat{s, s})
 	r := <-sp.c
 	if r.value != s.value {
 		t.Errorf("sent a stat and got a different one back")
@@ -36,22 +36,22 @@ func TestStatProcessorSendStats(t *testing.T) {
 
 	// should not send anything
 	wantLen := len(sp.c)
-	sp.sendStats(nil)
+	sp.send(nil)
 	time.Sleep(25 * time.Millisecond)
 	if got := len(sp.c); got != wantLen {
 		t.Errorf("empty stat array changed channel length: got %d want %d", got, wantLen)
 	}
 }
 
-func TestStatProcessorSendStatsWarm(t *testing.T) {
+func TestStatProcessorSendWarm(t *testing.T) {
 	s := GetStat()
 	if s.isWarm {
 		t.Errorf("initial stat came back warm unexpectedly")
 	}
 	s.value = 10.1
-	sp := &statProcessor{}
+	sp := &defaultStatProcessor{}
 	sp.c = make(chan *Stat, 2)
-	sp.sendStatsWarm([]*Stat{s, s})
+	sp.sendWarm([]*Stat{s, s})
 	r := <-sp.c
 	if r.value != s.value {
 		t.Errorf("sent a stat and got a different one back")
@@ -71,7 +71,7 @@ func TestStatProcessorSendStatsWarm(t *testing.T) {
 
 	// should not send anything
 	wantLen := len(sp.c)
-	sp.sendStatsWarm(nil)
+	sp.sendWarm(nil)
 	time.Sleep(25 * time.Millisecond)
 	if got := len(sp.c); got != wantLen {
 		t.Errorf("empty stat array changed channel length: got %d want %d", got, wantLen)


### PR DESCRIPTION
The statProcessor responsible for gathering statistics
when executing queries was built as a struct. This commit
will change it to an interface to make the BenchmarkRunner code
more easier to test. This commit also adds some unit tests for
the benchmark runner that check if proper argument checks are
done, and if proper init happens when the Run method is called