### PR TITLE
Add unit tests to query generation functions for various databases

### DIFF
--- a/cmd/tsbs_generate_queries/databases/clickhouse/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/clickhouse/devops_test.go
@@ -1,9 +1,13 @@
 package clickhouse
 
 import (
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/query"
 )
 
 func TestDevopsGetHostWhereWithHostnames(t *testing.T) {
@@ -82,5 +86,429 @@ func TestDevopsGetSelectClausesAggMetrics(t *testing.T) {
 		if got := strings.Join(d.getSelectClausesAggMetrics(c.agg, c.metrics), ","); got != c.want {
 			t.Errorf("%s: incorrect output: got %s want %s", c.desc, got, c.want)
 		}
+	}
+}
+
+func TestMaxAllCPU(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative hosts",
+			input:   -1,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got -1",
+		},
+		{
+			desc:    "zero hosts",
+			input:   0,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got 0",
+		},
+		{
+			desc:               "1 host",
+			input:              1,
+			expectedHumanLabel: "ClickHouse max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc: "ClickHouse max of all CPU metrics, random    1 hosts, " +
+				"random 8h0m0s by 1h: 1970-01-01T00:47:30Z",
+			expectedQuery: `
+        SELECT
+            toStartOfHour(created_at) AS hour,
+            max(usage_user) AS max_usage_user, max(usage_system) AS max_usage_system, max(usage_idle) AS max_usage_idle, max(usage_nice) AS max_usage_nice, max(usage_iowait) AS max_usage_iowait, max(usage_irq) AS max_usage_irq, max(usage_softirq) AS max_usage_softirq, max(usage_steal) AS max_usage_steal, max(usage_guest) AS max_usage_guest, max(usage_guest_nice) AS max_usage_guest_nice
+        FROM cpu
+        WHERE (hostname = 'host_5') AND (created_at >= '1970-01-01 00:47:30') AND (created_at < '1970-01-01 08:47:30')
+        GROUP BY hour
+        ORDER BY hour
+        `,
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "ClickHouse max of all CPU metrics, random    5 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc:  "ClickHouse max of all CPU metrics, random    5 hosts, random 8h0m0s by 1h: 1970-01-01T00:17:45Z",
+			expectedQuery: `
+        SELECT
+            toStartOfHour(created_at) AS hour,
+            max(usage_user) AS max_usage_user, max(usage_system) AS max_usage_system, max(usage_idle) AS max_usage_idle, max(usage_nice) AS max_usage_nice, max(usage_iowait) AS max_usage_iowait, max(usage_irq) AS max_usage_irq, max(usage_softirq) AS max_usage_softirq, max(usage_steal) AS max_usage_steal, max(usage_guest) AS max_usage_guest, max(usage_guest_nice) AS max_usage_guest_nice
+        FROM cpu
+        WHERE (hostname = 'host_9' OR hostname = 'host_5' OR hostname = 'host_1' OR hostname = 'host_7' OR hostname = 'host_2') AND (created_at >= '1970-01-01 00:17:45') AND (created_at < '1970-01-01 08:17:45')
+        GROUP BY hour
+        ORDER BY hour
+        `,
+		},
+		{
+			desc:    "more hosts then cardinality (11)",
+			input:   11,
+			fail:    true,
+			failMsg: "number of hosts (11) larger than total hosts. See --scale (10)",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.MaxAllCPU(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.MaxAllDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestGroupByTimeAndPrimaryTag(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative metrics",
+			input:   -1,
+			fail:    true,
+			failMsg: "cannot get 0 metrics",
+		},
+		{
+			desc:    "zero metrics",
+			input:   0,
+			fail:    true,
+			failMsg: "cannot get 0 metrics",
+		},
+		{
+			desc:               "one metric",
+			input:              1,
+			expectedHumanLabel: "ClickHouse mean of 1 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "ClickHouse mean of 1 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:16:22Z",
+			expectedQuery: `
+        SELECT
+            hour,
+            hostname,
+            mean_usage_user
+        FROM
+        (
+            SELECT
+                toStartOfHour(created_at) AS hour,
+                tags_id AS id,
+                avg(usage_user) AS mean_usage_user
+            FROM cpu
+            WHERE (created_at >= '1970-01-01 00:16:22') AND (created_at < '1970-01-01 12:16:22')
+            GROUP BY
+                hour,
+                id
+        ) AS cpu_avg
+        
+        ORDER BY
+            hour ASC,
+            hostname
+        `,
+		},
+		{
+			desc:               "5 metrics",
+			input:              5,
+			expectedHumanLabel: "ClickHouse mean of 5 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "ClickHouse mean of 5 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:54:10Z",
+			expectedQuery: `
+        SELECT
+            hour,
+            hostname,
+            mean_usage_user, mean_usage_system, mean_usage_idle, mean_usage_nice, mean_usage_iowait
+        FROM
+        (
+            SELECT
+                toStartOfHour(created_at) AS hour,
+                tags_id AS id,
+                avg(usage_user) AS mean_usage_user, avg(usage_system) AS mean_usage_system, avg(usage_idle) AS mean_usage_idle, avg(usage_nice) AS mean_usage_nice, avg(usage_iowait) AS mean_usage_iowait
+            FROM cpu
+            WHERE (created_at >= '1970-01-01 00:54:10') AND (created_at < '1970-01-01 12:54:10')
+            GROUP BY
+                hour,
+                id
+        ) AS cpu_avg
+        
+        ORDER BY
+            hour ASC,
+            hostname
+        `,
+		},
+		{
+			desc:               "use tags",
+			input:              5,
+			devopsUseTags:      true,
+			expectedHumanLabel: "ClickHouse mean of 5 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "ClickHouse mean of 5 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:47:30Z",
+			expectedQuery: `
+        SELECT
+            hour,
+            hostname,
+            mean_usage_user, mean_usage_system, mean_usage_idle, mean_usage_nice, mean_usage_iowait
+        FROM
+        (
+            SELECT
+                toStartOfHour(created_at) AS hour,
+                tags_id AS id,
+                avg(usage_user) AS mean_usage_user, avg(usage_system) AS mean_usage_system, avg(usage_idle) AS mean_usage_idle, avg(usage_nice) AS mean_usage_nice, avg(usage_iowait) AS mean_usage_iowait
+            FROM cpu
+            WHERE (created_at >= '1970-01-01 00:47:30') AND (created_at < '1970-01-01 12:47:30')
+            GROUP BY
+                hour,
+                id
+        ) AS cpu_avg
+        ANY INNER JOIN tags USING (id)
+        ORDER BY
+            hour ASC,
+            hostname
+        `,
+		},
+		{
+			desc:    "more metrics then it exists",
+			input:   99,
+			fail:    true,
+			failMsg: "too many metrics asked for",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByTimeAndPrimaryTag(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.DoubleGroupByDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestGroupByOrderByLimit(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:               "happy path",
+			expectedHumanLabel: "ClickHouse max cpu over last 5 min-intervals (random end)",
+			expectedHumanDesc:  "ClickHouse max cpu over last 5 min-intervals (random end): 1970-01-01T01:16:22Z",
+			expectedQuery: `
+        SELECT
+            toStartOfMinute(created_at) AS minute,
+            max(usage_user)
+        FROM cpu
+        WHERE created_at < '1970-01-01 01:16:22'
+        GROUP BY minute
+        ORDER BY minute DESC
+        LIMIT 5
+        `,
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByOrderByLimit(q)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestHighCPUForHosts(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative hosts",
+			input:   -1,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got -1",
+		},
+		{
+			desc:               "zero hosts",
+			input:              0,
+			expectedHumanLabel: "ClickHouse CPU over threshold, all hosts",
+			expectedHumanDesc:  "ClickHouse CPU over threshold, all hosts: 1970-01-01T00:16:22Z",
+			expectedQuery: `
+        SELECT *
+        FROM cpu
+        PREWHERE (usage_user > 90.0) AND (created_at >= '1970-01-01 00:16:22') AND (created_at <  '1970-01-01 12:16:22') 
+        `,
+		},
+		{
+			desc:               "one host",
+			input:              1,
+			expectedHumanLabel: "ClickHouse CPU over threshold, 1 host(s)",
+			expectedHumanDesc:  "ClickHouse CPU over threshold, 1 host(s): 1970-01-01T00:47:30Z",
+			expectedQuery: `
+        SELECT *
+        FROM cpu
+        PREWHERE (usage_user > 90.0) AND (created_at >= '1970-01-01 00:47:30') AND (created_at <  '1970-01-01 12:47:30') AND ((hostname = 'host_9'))
+        `,
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "ClickHouse CPU over threshold, 5 host(s)",
+			expectedHumanDesc:  "ClickHouse CPU over threshold, 5 host(s): 1970-01-01T00:08:59Z",
+			expectedQuery: `
+        SELECT *
+        FROM cpu
+        PREWHERE (usage_user > 90.0) AND (created_at >= '1970-01-01 00:08:59') AND (created_at <  '1970-01-01 12:08:59') AND ((hostname = 'host_5' OR hostname = 'host_9' OR hostname = 'host_1' OR hostname = 'host_7' OR hostname = 'host_2'))
+        `,
+		},
+		{
+			desc:    "more hosts then cardinality (11)",
+			input:   11,
+			fail:    true,
+			failMsg: "number of hosts (11) larger than total hosts. See --scale (10)",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.HighCPUForHosts(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.HighCPUDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestLastPointPerHost(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:               "happy path",
+			expectedHumanLabel: "ClickHouse last row per host",
+			expectedHumanDesc:  "ClickHouse last row per host",
+			expectedQuery: `
+            SELECT DISTINCT(hostname), *
+            FROM cpu
+            ORDER BY
+                hostname ASC,
+                created_at DESC
+            `,
+		},
+		{
+			desc:               "use tags",
+			devopsUseTags:      true,
+			expectedHumanLabel: "ClickHouse last row per host",
+			expectedHumanDesc:  "ClickHouse last row per host",
+			expectedQuery: `
+            SELECT *
+            FROM
+            (
+                SELECT *
+                FROM cpu
+                WHERE (tags_id, created_at) IN
+                (
+                    SELECT
+                        tags_id,
+                        max(created_at)
+                    FROM cpu
+                    GROUP BY tags_id
+                )
+            ) AS c
+            ANY INNER JOIN tags AS t ON c.tags_id = t.id
+            ORDER BY
+                t.hostname ASC,
+                c.time DESC
+            `,
+		},
+	}
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.LastPointPerHost(q)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.HighCPUDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestGroupByTime(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:               "happy path",
+			input:              1,
+			expectedHumanLabel: "ClickHouse 1 cpu metric(s), random    1 hosts, random 1s by 1m",
+			expectedHumanDesc:  "ClickHouse 1 cpu metric(s), random    1 hosts, random 1s by 1m: 1970-01-01T01:09:26Z",
+			expectedQuery: `
+        SELECT
+            toStartOfMinute(created_at) AS minute,
+            max(usage_user) AS max_usage_user
+        FROM cpu
+        WHERE (hostname = 'host_9') AND (created_at >= '1970-01-01 01:09:26') AND (created_at < '1970-01-01 01:09:27')
+        GROUP BY minute
+        ORDER BY minute ASC
+        `,
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByTime(q, c.input, 1, time.Second)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+type testCase struct {
+	desc               string
+	input              int
+	devopsUseTags      bool
+	fail               bool
+	failMsg            string
+	expectedHumanLabel string
+	expectedHumanDesc  string
+	expectedQuery      string
+}
+
+func runTestCases(t *testing.T, testFunc func(*Devops, testCase) query.Query, s time.Time, e time.Time, cases []testCase) {
+	rand.Seed(123) // Setting seed for testing purposes.
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			d := NewDevops(s, e, 10)
+			d.UseTags = c.devopsUseTags
+
+			if c.fail {
+				func() {
+					defer func() {
+						r := recover()
+						if r == nil {
+							t.Errorf("did not panic when should")
+						}
+
+						if r != c.failMsg {
+							t.Fatalf("incorrect fail message: got %s, want %s", r, c.failMsg)
+						}
+					}()
+
+					testFunc(d, c)
+				}()
+			} else {
+				q := testFunc(d, c)
+
+				verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+			}
+
+		})
+	}
+}
+
+func verifyQuery(t *testing.T, q query.Query, humanLabel, humanDesc, sqlQuery string) {
+	clickhouseql, ok := q.(*query.ClickHouse)
+
+	if !ok {
+		t.Fatal("Filled query is not *query.Clickhouse type")
+	}
+
+	if got := string(clickhouseql.HumanLabel); got != humanLabel {
+		t.Errorf("incorrect human label:\ngot\n%s\nwant\n%s", got, humanLabel)
+	}
+
+	if got := string(clickhouseql.HumanDescription); got != humanDesc {
+		t.Errorf("incorrect human description:\ngot\n%s\nwant\n%s", got, humanDesc)
+	}
+
+	if got := string(clickhouseql.SqlQuery); got != sqlQuery {
+		t.Errorf("incorrect query:\ngot\n%s\nwant\n%s", got, sqlQuery)
 	}
 }

--- a/cmd/tsbs_generate_queries/databases/influx/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/influx/devops_test.go
@@ -1,11 +1,14 @@
 package influx
 
 import (
+	"fmt"
+	"math/rand"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
 	"github.com/timescale/tsbs/query"
 )
 
@@ -33,12 +36,49 @@ func TestDevopsGetHostWhereWithHostnames(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		d := NewDevops(time.Now(), time.Now(), 10)
+		t.Run(c.desc, func(t *testing.T) {
+			d := NewDevops(time.Now(), time.Now(), 10)
 
-		if got := d.getHostWhereWithHostnames(c.hostnames); got != c.want {
-			t.Errorf("%s: incorrect output: got %s want %s", c.desc, got, c.want)
-		}
+			if got := d.getHostWhereWithHostnames(c.hostnames); got != c.want {
+				t.Errorf("incorrect output: got %s want %s", got, c.want)
+			}
+		})
 	}
+}
+
+func TestDevopsGetHostWhereString(t *testing.T) {
+	cases := []struct {
+		desc   string
+		nHosts int
+		want   string
+	}{
+		{
+			desc:   "single host",
+			nHosts: 1,
+			want:   "(hostname = 'host_1')",
+		},
+		{
+			desc:   "multi host (2)",
+			nHosts: 2,
+			want:   "(hostname = 'host_7' or hostname = 'host_9')",
+		},
+		{
+			desc:   "multi host (3)",
+			nHosts: 3,
+			want:   "(hostname = 'host_1' or hostname = 'host_8' or hostname = 'host_5')",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			d := NewDevops(time.Now(), time.Now(), 10)
+
+			if got := d.getHostWhereString(c.nHosts); got != c.want {
+				t.Errorf("incorrect output:\ngot\n%s\nwant\n%s", got, c.want)
+			}
+		})
+	}
+
 }
 
 func TestDevopsGetSelectClausesAggMetrics(t *testing.T) {
@@ -69,12 +109,219 @@ func TestDevopsGetSelectClausesAggMetrics(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		d := NewDevops(time.Now(), time.Now(), 10)
+		t.Run(c.desc, func(t *testing.T) {
+			d := NewDevops(time.Now(), time.Now(), 10)
 
-		if got := strings.Join(d.getSelectClausesAggMetrics(c.agg, c.metrics), ","); got != c.want {
-			t.Errorf("%s: incorrect output: got %s want %s", c.desc, got, c.want)
-		}
+			if got := strings.Join(d.getSelectClausesAggMetrics(c.agg, c.metrics), ","); got != c.want {
+				t.Errorf("incorrect output: got %s want %s", got, c.want)
+			}
+		})
 	}
+}
+
+func TestDevopsGroupByTime(t *testing.T) {
+	expectedHumanLabel := "Influx 1 cpu metric(s), random    1 hosts, random 1s by 1m"
+	expectedHumanDesc := "Influx 1 cpu metric(s), random    1 hosts, random 1s by 1m: 1970-01-01T00:05:58Z"
+	expectedQuery := "SELECT max(usage_user) from cpu " +
+		"where (hostname = 'host_9') and " +
+		"time >= '1970-01-01T00:05:58Z' and time < '1970-01-01T00:05:59Z' " +
+		"group by time(1m)"
+
+	v := url.Values{}
+	v.Set("q", expectedQuery)
+	expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+	rand.Seed(123) // Setting seed for testing purposes.
+	s := time.Unix(0, 0)
+	e := s.Add(time.Hour)
+	d := NewDevops(s, e, 10)
+
+	metrics := 1
+	nHosts := 1
+	duration := time.Second
+
+	q := d.GenerateEmptyQuery()
+	d.GroupByTime(q, nHosts, metrics, duration)
+
+	verifyQuery(t, q, expectedHumanLabel, expectedHumanDesc, expectedPath)
+}
+
+func TestDevopsGroupByOrderByLimit(t *testing.T) {
+	expectedHumanLabel := "Influx max cpu over last 5 min-intervals (random end)"
+	expectedHumanDesc := "Influx max cpu over last 5 min-intervals (random end): 1970-01-01T00:16:22Z"
+	expectedQuery := "SELECT max(usage_user) from cpu " +
+		"WHERE time < '1970-01-01T01:16:22Z' group by time(1m) limit 5"
+
+	v := url.Values{}
+	v.Set("q", expectedQuery)
+	expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+	rand.Seed(123) // Setting seed for testing purposes.
+	s := time.Unix(0, 0)
+	e := s.Add(2 * time.Hour)
+	d := NewDevops(s, e, 10)
+
+	q := d.GenerateEmptyQuery()
+	d.GroupByOrderByLimit(q)
+
+	verifyQuery(t, q, expectedHumanLabel, expectedHumanDesc, expectedPath)
+}
+
+func TestDevopsGroupByTimeAndPrimaryTag(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "zero metrics",
+			input:   0,
+			fail:    true,
+			failMsg: "cannot get 0 metrics",
+		},
+		{
+			desc:               "1 metric",
+			input:              1,
+			expectedHumanLabel: "Influx mean of 1 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "Influx mean of 1 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:16:22Z",
+			expectedQuery: "SELECT mean(usage_user) from cpu " +
+				"where time >= '1970-01-01T00:16:22Z' and time < '1970-01-01T12:16:22Z' " +
+				"group by time(1h),hostname",
+		},
+		{
+			desc:               "5 metrics",
+			input:              5,
+			expectedHumanLabel: "Influx mean of 5 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "Influx mean of 5 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:54:10Z",
+			expectedQuery: "SELECT mean(usage_user), mean(usage_system), mean(usage_idle), mean(usage_nice), mean(usage_iowait) " +
+				"from cpu " +
+				"where time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T12:54:10Z' " +
+				"group by time(1h),hostname",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByTimeAndPrimaryTag(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.DoubleGroupByDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestMaxAllCPU(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "zero hosts",
+			input:   0,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got 0",
+		},
+		{
+			desc:               "1 host",
+			input:              1,
+			expectedHumanLabel: "Influx max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc:  "Influx max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h: 1970-01-01T00:54:10Z",
+			expectedQuery: "SELECT max(usage_user),max(usage_system),max(usage_idle),max(usage_nice),max(usage_iowait)," +
+				"max(usage_irq),max(usage_softirq),max(usage_steal),max(usage_guest),max(usage_guest_nice) " +
+				"from cpu " +
+				"where (hostname = 'host_3') and " +
+				"time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T08:54:10Z' " +
+				"group by time(1m)",
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "Influx max of all CPU metrics, random    5 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc:  "Influx max of all CPU metrics, random    5 hosts, random 8h0m0s by 1h: 1970-01-01T00:37:12Z",
+			expectedQuery: "SELECT max(usage_user),max(usage_system),max(usage_idle),max(usage_nice),max(usage_iowait)," +
+				"max(usage_irq),max(usage_softirq),max(usage_steal),max(usage_guest),max(usage_guest_nice) " +
+				"from cpu " +
+				"where (hostname = 'host_9' or hostname = 'host_5' or hostname = 'host_1' or hostname = 'host_7' or hostname = 'host_2') " +
+				"and time >= '1970-01-01T00:37:12Z' and time < '1970-01-01T08:37:12Z' " +
+				"group by time(1m)",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.MaxAllCPU(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.MaxAllDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestLastPointPerHost(t *testing.T) {
+	expectedHumanLabel := "Influx last row per host"
+	expectedHumanDesc := "Influx last row per host: cpu"
+	expectedQuery := `SELECT * from cpu group by "hostname" order by time desc limit 1`
+
+	v := url.Values{}
+	v.Set("q", expectedQuery)
+	expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+	rand.Seed(123) // Setting seed for testing purposes.
+	s := time.Unix(0, 0)
+	e := s.Add(2 * time.Hour)
+	d := NewDevops(s, e, 10)
+
+	q := d.GenerateEmptyQuery()
+	d.LastPointPerHost(q)
+
+	verifyQuery(t, q, expectedHumanLabel, expectedHumanDesc, expectedPath)
+}
+
+func TestHighCPUForHosts(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative hosts",
+			input:   -1,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got -1",
+		},
+		{
+			desc:               "zero hosts",
+			input:              0,
+			expectedHumanLabel: "Influx CPU over threshold, all hosts",
+			expectedHumanDesc:  "Influx CPU over threshold, all hosts: 1970-01-01T00:54:10Z",
+			expectedQuery: "SELECT * from cpu " +
+				"where usage_user > 90.0  and " +
+				"time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T12:54:10Z'",
+		},
+		{
+			desc:               "1 host",
+			input:              1,
+			expectedHumanLabel: "Influx CPU over threshold, 1 host(s)",
+			expectedHumanDesc:  "Influx CPU over threshold, 1 host(s): 1970-01-01T00:47:30Z",
+			expectedQuery: "SELECT * from cpu " +
+				"where usage_user > 90.0 and (hostname = 'host_5') and " +
+				"time >= '1970-01-01T00:47:30Z' and time < '1970-01-01T12:47:30Z'",
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "Influx CPU over threshold, 5 host(s)",
+			expectedHumanDesc:  "Influx CPU over threshold, 5 host(s): 1970-01-01T00:17:45Z",
+			expectedQuery: "SELECT * from cpu " +
+				"where usage_user > 90.0 and " +
+				"(hostname = 'host_9' or hostname = 'host_5' or hostname = 'host_1' or hostname = 'host_7' or hostname = 'host_2') and " +
+				"time >= '1970-01-01T00:17:45Z' and time < '1970-01-01T12:17:45Z'",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.HighCPUForHosts(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.HighCPUDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
 }
 
 func TestDevopsFillInQuery(t *testing.T) {
@@ -112,5 +359,79 @@ func TestDevopsFillInQuery(t *testing.T) {
 	encoded := v.Encode()
 	if got := string(q.Path); got != "/query?"+encoded {
 		t.Errorf("filled query has wrong path: got %s want /query?%s", got, encoded)
+	}
+}
+
+type testCase struct {
+	desc               string
+	input              int
+	fail               bool
+	failMsg            string
+	expectedHumanLabel string
+	expectedHumanDesc  string
+	expectedQuery      string
+}
+
+func runTestCases(t *testing.T, testFunc func(*Devops, testCase) query.Query, s time.Time, e time.Time, cases []testCase) {
+	rand.Seed(123) // Setting seed for testing purposes.
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			d := NewDevops(s, e, 10)
+
+			if c.fail {
+				func() {
+					defer func() {
+						r := recover()
+						if r == nil {
+							t.Errorf("did not panic when should")
+						}
+
+						if r != c.failMsg {
+							t.Fatalf("incorrect fail message: got %s, want %s", r, c.failMsg)
+						}
+					}()
+
+					testFunc(d, c)
+				}()
+			} else {
+				q := testFunc(d, c)
+
+				v := url.Values{}
+				v.Set("q", c.expectedQuery)
+				expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+				verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, expectedPath)
+			}
+
+		})
+	}
+}
+
+func verifyQuery(t *testing.T, q query.Query, humanLabel, humanDesc, path string) {
+	influxql, ok := q.(*query.HTTP)
+
+	if !ok {
+		t.Fatal("Filled query is not *query.HTTP type")
+	}
+
+	if got := string(influxql.HumanLabel); got != humanLabel {
+		t.Errorf("incorrect human label:\ngot\n%s\nwant\n%s", got, humanLabel)
+	}
+
+	if got := string(influxql.HumanDescription); got != humanDesc {
+		t.Errorf("incorrect human description:\ngot\n%s\nwant\n%s", got, humanDesc)
+	}
+
+	if got := string(influxql.Method); got != "GET" {
+		t.Errorf("incorrect method:\ngot\n%s\nwant GET", got)
+	}
+
+	if got := string(influxql.Path); got != path {
+		t.Errorf("incorrect path:\ngot\n%s\nwant\n%s", got, path)
+	}
+
+	if influxql.Body != nil {
+		t.Errorf("body not nil, got %+v", influxql.Body)
 	}
 }

--- a/cmd/tsbs_generate_queries/databases/siridb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/siridb/devops_test.go
@@ -1,9 +1,11 @@
 package siridb
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
 	"github.com/timescale/tsbs/query"
 )
 
@@ -66,6 +68,249 @@ func TestDevopsGetMetricWhereWithMetrics(t *testing.T) {
 	}
 }
 
+func TestGroupByTime(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:               "one metric",
+			input:              1,
+			expectedHumanLabel: "SiriDB 1 cpu metric(s), random    1 hosts, random 1s by 1m",
+			expectedHumanDesc: "SiriDB 1 cpu metric(s), random    1 hosts, " +
+				"random 1s by 1m: 1970-01-01T01:09:26Z",
+			expectedQuery: "select max(1m) " +
+				"from (`host_9`) & (`usage_user`) " +
+				"between '1970-01-01T01:09:26Z' and '1970-01-01T01:09:27Z' " +
+				"merge as 'max (`usage_user`) " +
+				"for (`host_9`)' using max(1)",
+		},
+		{
+			desc:               "two metrics",
+			input:              2,
+			expectedHumanLabel: "SiriDB 2 cpu metric(s), random    1 hosts, random 1s by 1m",
+			expectedHumanDesc: "SiriDB 2 cpu metric(s), random    1 hosts, " +
+				"random 1s by 1m: 1970-01-01T00:45:11Z",
+			expectedQuery: "select max(1m) " +
+				"from (`host_5`) & (`usage_user`|`usage_system`) " +
+				"between '1970-01-01T00:45:11Z' and '1970-01-01T00:45:12Z'",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByTime(q, 1, c.input, time.Second)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestGroupByOrderByLimit(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:               "happy path",
+			expectedHumanLabel: "SiriDB max cpu over last 5 min-intervals (random end)",
+			expectedHumanDesc: "SiriDB max cpu over last 5 min-intervals " +
+				"(random end): 1970-01-01T01:16:22Z",
+			expectedQuery: "select max(1m) " +
+				"from `usage_user` " +
+				"between '1970-01-01 01:16:22Z' - 5m and '1970-01-01 01:16:00Z' " +
+				"merge as 'max usage user of the last 5 aggregate readings' using max(1)",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByOrderByLimit(q)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestGroupByTimeAndPrimaryTag(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative metrics",
+			input:   -1,
+			fail:    true,
+			failMsg: "cannot get 0 metrics",
+		},
+		{
+			desc:    "zero metrics",
+			input:   0,
+			fail:    true,
+			failMsg: "cannot get 0 metrics",
+		},
+		{
+			desc:               "one metric",
+			input:              1,
+			expectedHumanLabel: "SiriDB mean of 1 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "SiriDB mean of 1 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:47:30Z",
+			expectedQuery: "select mean(1h) from (`usage_user`) " +
+				"between '1970-01-01T00:47:30Z' and '1970-01-01T12:47:30Z'",
+		},
+		{
+			desc:               "5 metrics",
+			input:              5,
+			expectedHumanLabel: "SiriDB mean of 5 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "SiriDB mean of 5 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:37:12Z",
+			expectedQuery: "select mean(1h) " +
+				"from (`usage_user`|`usage_system`|`usage_idle`|`usage_nice`|`usage_iowait`) " +
+				"between '1970-01-01T00:37:12Z' and '1970-01-01T12:37:12Z'",
+		},
+		{
+			desc:    "more metrics then it exists",
+			input:   99,
+			fail:    true,
+			failMsg: "too many metrics asked for",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByTimeAndPrimaryTag(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.DoubleGroupByDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestMaxAllCPU(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative hosts",
+			input:   -1,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got -1",
+		},
+		{
+			desc:    "zero hosts",
+			input:   0,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got 0",
+		},
+		{
+			desc:               "1 host",
+			input:              1,
+			expectedHumanLabel: "SiriDB max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc: "SiriDB max of all CPU metrics, random    1 hosts, " +
+				"random 8h0m0s by 1h: 1970-01-01T00:47:30Z",
+			expectedQuery: "select max(1h) from (`host_5`) & `cpu` " +
+				"between '1970-01-01T00:47:30Z' and '1970-01-01T08:47:30Z'",
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "SiriDB max of all CPU metrics, random    5 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc: "SiriDB max of all CPU metrics, random    5 hosts, " +
+				"random 8h0m0s by 1h: 1970-01-01T00:17:45Z",
+			expectedQuery: "select max(1h) " +
+				"from (`host_9`|`host_5`|`host_1`|`host_7`|`host_2`) & `cpu` " +
+				"between '1970-01-01T00:17:45Z' and '1970-01-01T08:17:45Z'",
+		},
+		{
+			desc:    "more hosts then cardinality (11)",
+			input:   11,
+			fail:    true,
+			failMsg: "number of hosts (11) larger than total hosts. See --scale (10)",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.MaxAllCPU(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.MaxAllDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestLastPointPerHost(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:               "happy path",
+			expectedHumanLabel: "SiriDB last row per host",
+			expectedHumanDesc:  "SiriDB last row per host",
+			expectedQuery:      "select last() from `cpu`",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.LastPointPerHost(q)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestHighCPUForHosts(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative hosts",
+			input:   -1,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got -1",
+		},
+		{
+			desc:               "zero hosts",
+			input:              0,
+			expectedHumanLabel: "SiriDB CPU over threshold, all hosts",
+			expectedHumanDesc:  "SiriDB CPU over threshold, all hosts: 1970-01-01T00:16:22Z",
+			expectedQuery: "select filter(> 90) from `usage_user`  " +
+				"between '1970-01-01T00:16:22Z' and '1970-01-01T12:16:22Z'",
+		},
+		{
+			desc:               "one host",
+			input:              1,
+			expectedHumanLabel: "SiriDB CPU over threshold, 1 host(s)",
+			expectedHumanDesc:  "SiriDB CPU over threshold, 1 host(s): 1970-01-01T00:47:30Z",
+			expectedQuery: "select filter(> 90) from `usage_user` & (`host_9`) " +
+				"between '1970-01-01T00:47:30Z' and '1970-01-01T12:47:30Z'",
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "SiriDB CPU over threshold, 5 host(s)",
+			expectedHumanDesc:  "SiriDB CPU over threshold, 5 host(s): 1970-01-01T00:08:59Z",
+			expectedQuery: "select filter(> 90) " +
+				"from `usage_user` & (`host_5`|`host_9`|`host_1`|`host_7`|`host_2`) " +
+				"between '1970-01-01T00:08:59Z' and '1970-01-01T12:08:59Z'",
+		},
+		{
+			desc:    "more hosts then cardinality (11)",
+			input:   11,
+			fail:    true,
+			failMsg: "number of hosts (11) larger than total hosts. See --scale (10)",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.HighCPUForHosts(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.HighCPUDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
 func TestDevopsFillInQuery(t *testing.T) {
 	humanLabel := "this is my label"
 	humanDesc := "and now my description"
@@ -92,5 +337,67 @@ func TestDevopsFillInQuery(t *testing.T) {
 	}
 	if got := string(q.SqlQuery); got != siriql {
 		t.Errorf("Wrong query: got %s want %s", got, siriql)
+	}
+}
+
+type testCase struct {
+	desc               string
+	input              int
+	fail               bool
+	failMsg            string
+	expectedHumanLabel string
+	expectedHumanDesc  string
+	expectedQuery      string
+}
+
+func runTestCases(t *testing.T, testFunc func(*Devops, testCase) query.Query, s time.Time, e time.Time, cases []testCase) {
+	rand.Seed(123) // Setting seed for testing purposes.
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			d := NewDevops(s, e, 10)
+
+			if c.fail {
+				func() {
+					defer func() {
+						r := recover()
+						if r == nil {
+							t.Errorf("did not panic when should")
+						}
+
+						if r != c.failMsg {
+							t.Fatalf("incorrect fail message: got %s, want %s", r, c.failMsg)
+						}
+					}()
+
+					testFunc(d, c)
+				}()
+			} else {
+				q := testFunc(d, c)
+
+				verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+			}
+
+		})
+	}
+}
+
+func verifyQuery(t *testing.T, q query.Query, humanLabel, humanDesc, sqlQuery string) {
+	siridbq, ok := q.(*query.SiriDB)
+
+	if !ok {
+		t.Fatal("Filled query is not *query.SiriDB type")
+	}
+
+	if got := string(siridbq.HumanLabel); got != humanLabel {
+		t.Errorf("incorrect human label:\ngot\n%s\nwant\n%s", got, humanLabel)
+	}
+
+	if got := string(siridbq.HumanDescription); got != humanDesc {
+		t.Errorf("incorrect human description:\ngot\n%s\nwant\n%s", got, humanDesc)
+	}
+
+	if got := string(siridbq.SqlQuery); got != sqlQuery {
+		t.Errorf("incorrect query:\ngot\n%s\nwant\n%s", got, sqlQuery)
 	}
 }


### PR DESCRIPTION
Covering query generation functions for Influx, ClickHouse and SiriDB
databases. Tests are covering basic pre-generated outputs and provide
visual sanity checks. More robust tests are left as a future task.