### PR TITLE
Rename DevopsGenerator to QueryGenerator

### DIFF
--- a/cmd/tsbs_generate_queries/uses/devops/common.go
+++ b/cmd/tsbs_generate_queries/uses/devops/common.go
@@ -202,6 +202,6 @@ func getRandomSubsetPerm(numItems int, totalItems int) ([]int, error) {
 	return res, nil
 }
 
-func panicUnimplementedQuery(dg utils.DevopsGenerator) {
+func panicUnimplementedQuery(dg utils.QueryGenerator) {
 	panic(fmt.Sprintf("database (%v) does not implement query", reflect.TypeOf(dg)))
 }

--- a/cmd/tsbs_generate_queries/uses/devops/groupby.go
+++ b/cmd/tsbs_generate_queries/uses/devops/groupby.go
@@ -7,13 +7,13 @@ import (
 
 // Groupby produces a QueryFiller for the devops groupby case.
 type Groupby struct {
-	core       utils.DevopsGenerator
+	core       utils.QueryGenerator
 	numMetrics int
 }
 
 // NewGroupBy produces a function that produces a new Groupby for the given parameters
 func NewGroupBy(numMetrics int) utils.QueryFillerMaker {
-	return func(core utils.DevopsGenerator) utils.QueryFiller {
+	return func(core utils.QueryGenerator) utils.QueryFiller {
 		return &Groupby{
 			core:       core,
 			numMetrics: numMetrics,

--- a/cmd/tsbs_generate_queries/uses/devops/groupby_orderby_limit.go
+++ b/cmd/tsbs_generate_queries/uses/devops/groupby_orderby_limit.go
@@ -7,11 +7,11 @@ import (
 
 // GroupByOrderByLimit produces a filler for queries in the devops groupby-orderby-limit case.
 type GroupByOrderByLimit struct {
-	core utils.DevopsGenerator
+	core utils.QueryGenerator
 }
 
 // NewGroupByOrderByLimit returns a new GroupByOrderByLimit for given paremeters
-func NewGroupByOrderByLimit(core utils.DevopsGenerator) utils.QueryFiller {
+func NewGroupByOrderByLimit(core utils.QueryGenerator) utils.QueryFiller {
 	return &GroupByOrderByLimit{core}
 }
 

--- a/cmd/tsbs_generate_queries/uses/devops/high_cpu.go
+++ b/cmd/tsbs_generate_queries/uses/devops/high_cpu.go
@@ -7,13 +7,13 @@ import (
 
 // HighCPU produces a QueryFiller for the devops high-cpu cases
 type HighCPU struct {
-	core  utils.DevopsGenerator
+	core  utils.QueryGenerator
 	hosts int
 }
 
 // NewHighCPU produces a new function that produces a new HighCPU
 func NewHighCPU(hosts int) utils.QueryFillerMaker {
-	return func(core utils.DevopsGenerator) utils.QueryFiller {
+	return func(core utils.QueryGenerator) utils.QueryFiller {
 		return &HighCPU{
 			core:  core,
 			hosts: hosts,

--- a/cmd/tsbs_generate_queries/uses/devops/lastpoint.go
+++ b/cmd/tsbs_generate_queries/uses/devops/lastpoint.go
@@ -7,11 +7,11 @@ import (
 
 // LastPointPerHost returns QueryFiller for the devops lastpoint case
 type LastPointPerHost struct {
-	core utils.DevopsGenerator
+	core utils.QueryGenerator
 }
 
 // NewLastPointPerHost returns a new LastPointPerHost for given paremeters
-func NewLastPointPerHost(core utils.DevopsGenerator) utils.QueryFiller {
+func NewLastPointPerHost(core utils.QueryGenerator) utils.QueryFiller {
 	return &LastPointPerHost{core}
 }
 

--- a/cmd/tsbs_generate_queries/uses/devops/max_all_cpu.go
+++ b/cmd/tsbs_generate_queries/uses/devops/max_all_cpu.go
@@ -7,13 +7,13 @@ import (
 
 // MaxAllCPU contains info for filling in a query.Query for "max all" queries
 type MaxAllCPU struct {
-	core  utils.DevopsGenerator
+	core  utils.QueryGenerator
 	hosts int
 }
 
 // NewMaxAllCPU produces a new function that produces a new AllMaxCPU
 func NewMaxAllCPU(hosts int) utils.QueryFillerMaker {
-	return func(core utils.DevopsGenerator) utils.QueryFiller {
+	return func(core utils.QueryGenerator) utils.QueryFiller {
 		return &MaxAllCPU{
 			core:  core,
 			hosts: hosts,

--- a/cmd/tsbs_generate_queries/uses/devops/single_groupby.go
+++ b/cmd/tsbs_generate_queries/uses/devops/single_groupby.go
@@ -9,7 +9,7 @@ import (
 
 // SingleGroupby contains info for filling in single groupby queries
 type SingleGroupby struct {
-	core    utils.DevopsGenerator
+	core    utils.QueryGenerator
 	metrics int
 	hosts   int
 	hours   int
@@ -17,7 +17,7 @@ type SingleGroupby struct {
 
 // NewSingleGroupby produces a new function that produces a new SingleGroupby
 func NewSingleGroupby(metrics, hosts, hours int) utils.QueryFillerMaker {
-	return func(core utils.DevopsGenerator) utils.QueryFiller {
+	return func(core utils.QueryGenerator) utils.QueryFiller {
 		return &SingleGroupby{
 			core:    core,
 			metrics: metrics,

--- a/cmd/tsbs_generate_queries/utils/query_generator.go
+++ b/cmd/tsbs_generate_queries/utils/query_generator.go
@@ -2,8 +2,11 @@ package utils
 
 import "github.com/timescale/tsbs/query"
 
-// DevopsGenerator is query generator for a database type that handles the Devops use case
-type DevopsGenerator interface {
+// QueryGenerator is an interface that a database-specific implementation of a
+// use case implements to set basic configuration that can then be used by
+// a specific QueryFiller, ultimately yielding a query.Query with information
+// to be run.
+type QueryGenerator interface {
 	GenerateEmptyQuery() query.Query
 }
 
@@ -13,5 +16,5 @@ type QueryFiller interface {
 	Fill(query.Query) query.Query
 }
 
-// QueryFillerMaker is a function that takes a DevopsGenerator and returns a QueryFiller
-type QueryFillerMaker func(DevopsGenerator) QueryFiller
+// QueryFillerMaker is a function that takes a QueryGenerator and returns a QueryFiller
+type QueryFillerMaker func(QueryGenerator) QueryFiller

--- a/internal/inputs/generator_queries.go
+++ b/internal/inputs/generator_queries.go
@@ -173,8 +173,8 @@ func (g *QueryGenerator) init(config GeneratorConfig) error {
 	return nil
 }
 
-func (g *QueryGenerator) getUseCaseGenerator(c *QueryGeneratorConfig) (utils.DevopsGenerator, error) {
-	var ret utils.DevopsGenerator
+func (g *QueryGenerator) getUseCaseGenerator(c *QueryGeneratorConfig) (utils.QueryGenerator, error) {
+	var ret utils.QueryGenerator
 	scale := int(c.Scale) // TODO: make all the Devops constructors use a uint64
 
 	switch c.Format {
@@ -206,7 +206,7 @@ func (g *QueryGenerator) getUseCaseGenerator(c *QueryGeneratorConfig) (utils.Dev
 	return ret, nil
 }
 
-func (g *QueryGenerator) runQueryGeneration(useGen utils.DevopsGenerator, filler utils.QueryFiller, c *QueryGeneratorConfig) error {
+func (g *QueryGenerator) runQueryGeneration(useGen utils.QueryGenerator, filler utils.QueryFiller, c *QueryGeneratorConfig) error {
 	stats := make(map[string]int64)
 	currentGroup := uint(0)
 	enc := gob.NewEncoder(g.bufOut)

--- a/internal/inputs/generator_queries_test.go
+++ b/internal/inputs/generator_queries_test.go
@@ -220,7 +220,7 @@ func TestGetUseCaseGenerator(t *testing.T) {
 		tsStart: tsStart,
 		tsEnd:   tsEnd,
 	}
-	checkType := func(format string, want utils.DevopsGenerator) utils.DevopsGenerator {
+	checkType := func(format string, want utils.QueryGenerator) utils.QueryGenerator {
 		wantType := reflect.TypeOf(want)
 		c.Format = format
 		useGen, err := g.getUseCaseGenerator(c)


### PR DESCRIPTION
This interface is not tied to the devops use case in any way, so
its naming was a misnomer. It is actually generic and can be used
for any use case since, so this renaming reflects that.