### PR TITLE
Fix argument name

### DIFF
--- a/scripts/generate_run_script.py
+++ b/scripts/generate_run_script.py
@@ -18,6 +18,8 @@ Usage flags:
 
     -l      Directory where input files are located. They should be named
             `[database]-data.gz` (default: /tmp)
+            
+    -n      Number of queries to run for each query type (default: 1000)
 
     -o      Directory where query files are located (default: /tmp/queries)
 
@@ -137,7 +139,7 @@ if __name__ == "__main__":
         action='store_true', help='Whether to only generate commands for inserts')
     parser.add_argument('-l', dest='load_file_dir', default=default_load_dir,
         type=str, help='Path to directory where data to insert is stored')
-    parser.add_argument('-n', dest='max-queries', default=1000, type=int,
+    parser.add_argument('-n', dest='limit', default=1000, type=int,
         help='Max number of queries to run')
     parser.add_argument('-o', dest='query_file_dir', default=default_query_dir,
         type=str, help='Path to directory where queries to execute are stored')


### PR DESCRIPTION
Previously, the -n flag sent its data to the "max-queries" variable, which results in an unknown variable name when running the script because the python variable used to generate the run script is 'limit' (see line 163). "Max-queries" is only applicable as a flag for the tsbs_run_queries script, i.e., "--max-queries=###".