### PR TITLE
Improve Timescale query timing by confirming query completion

### DIFF
--- a/cmd/tsbs_run_queries_timescaledb/main.go
+++ b/cmd/tsbs_run_queries_timescaledb/main.go
@@ -204,7 +204,13 @@ func (p *processor) ProcessQuery(q query.Query, isWarm bool) ([]*query.Stat, err
 	} else if p.opts.printResponse {
 		prettyPrintResponse(rows, tq)
 	}
+	// Fetching all the rows to confirm that the query is fully completed.
+	for rows.Next() {
+	}
 	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	took := float64(time.Since(start).Nanoseconds()) / 1e6
 	stat := query.GetStat()
 	stat.Init(q.HumanLabelName(), took)


### PR DESCRIPTION
When using the `pgx` sql driver, running the query does not wait for a
response from the server. In order to verify that the query has returned
complete results, we must run `Rows.Next()` until it returns false
meaning we have fetched all the rows from the query result. Note that
this behavior is different than the current implementation of the `pq`
driver.