### PR TITLE
Add new IoT query for Timescale and Influx databases

### DIFF
--- a/cmd/tsbs_generate_queries/databases/influx/iot.go
+++ b/cmd/tsbs_generate_queries/databases/influx/iot.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases"
@@ -23,6 +24,39 @@ func NewIoT(start, end time.Time, scale int, g *BaseGenerator) *IoT {
 		Core:          c,
 		BaseGenerator: g,
 	}
+}
+
+func (i *IoT) getTrucksWhereWithNames(names []string) string {
+	nameClauses := []string{}
+	for _, s := range names {
+		nameClauses = append(nameClauses, fmt.Sprintf("\"name\" = '%s'", s))
+	}
+
+	combinedHostnameClause := strings.Join(nameClauses, " or ")
+	return "(" + combinedHostnameClause + ")"
+}
+
+func (i *IoT) getTruckWhereString(nTrucks int) string {
+	names, err := i.GetRandomTrucks(nTrucks)
+	if err != nil {
+		panic(err.Error())
+	}
+	return i.getTrucksWhereWithNames(names)
+}
+
+// LastLocByTruck finds the truck location for nTrucks.
+func (i *IoT) LastLocByTruck(qi query.Query, nTrucks int) {
+	influxql := fmt.Sprintf(`SELECT "name", "driver", "latitude", "longitude" 
+		FROM "readings" 
+		WHERE %s 
+		ORDER BY "time" 
+		LIMIT 1`,
+		i.getTruckWhereString(nTrucks))
+
+	humanLabel := "Influx last location by specific truck"
+	humanDesc := fmt.Sprintf("%s: random %4d trucks", humanLabel, nTrucks)
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
 }
 
 // LastLocPerTruck finds all the truck locations along with truck and driver names.

--- a/cmd/tsbs_generate_queries/main.go
+++ b/cmd/tsbs_generate_queries/main.go
@@ -33,6 +33,7 @@ var useCaseMatrix = map[string]map[string]utils.QueryFillerMaker{
 	},
 	"iot": {
 		iot.LabelLastLoc:                       iot.NewLastLocPerTruck,
+		iot.LabelLastLocSingleTruck:            iot.NewLastLocSingleTruck,
 		iot.LabelLowFuel:                       iot.NewTruckWithLowFuel,
 		iot.LabelHighLoad:                      iot.NewTruckWithHighLoad,
 		iot.LabelStationaryTrucks:              iot.NewStationaryTrucks,

--- a/cmd/tsbs_generate_queries/uses/common/common.go
+++ b/cmd/tsbs_generate_queries/uses/common/common.go
@@ -2,11 +2,16 @@ package common
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"time"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
 	internalutils "github.com/timescale/tsbs/internal/utils"
+)
+
+const (
+	errMoreItemsThanScale = "cannot get random permutation with more items than scale"
 )
 
 // Core is the common component of all generators for all systems
@@ -31,4 +36,31 @@ func NewCore(start, end time.Time, scale int) (*Core, error) {
 // PanicUnimplementedQuery generates a panic for the provided query generator.
 func PanicUnimplementedQuery(dg utils.QueryGenerator) {
 	panic(fmt.Sprintf("database (%v) does not implement query", reflect.TypeOf(dg)))
+}
+
+// GetRandomSubsetPerm returns a subset of numItems of a permutation of numbers from 0 to totalNumbers,
+// e.g., 5 items out of 30. This is an alternative to rand.Perm and then taking a sub-slice,
+// which used up a lot more memory and slowed down query generation significantly.
+// The subset of the permutation should have no duplicates and thus, can not be longer that original set
+// Ex.: 12, 7, 25 for numItems=3 and totalItems=30 (3 out of 30)
+func GetRandomSubsetPerm(numItems int, totalItems int) ([]int, error) {
+	if numItems > totalItems {
+		// Cannot make a subset longer than the original set
+		return nil, fmt.Errorf(errMoreItemsThanScale)
+	}
+
+	seen := map[int]bool{}
+	res := make([]int, numItems)
+	for i := 0; i < numItems; i++ {
+		for {
+			n := rand.Intn(totalItems)
+			// Keep iterating until a previously unseen int is found
+			if !seen[n] {
+				seen[n] = true
+				res[i] = n
+				break
+			}
+		}
+	}
+	return res, nil
 }

--- a/cmd/tsbs_generate_queries/uses/common/common_test.go
+++ b/cmd/tsbs_generate_queries/uses/common/common_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -31,5 +32,46 @@ func TestNewCoreEndBeforeStart(t *testing.T) {
 	_, err := NewCore(s, e, 10)
 	if got := err.Error(); got != utils.ErrEndBeforeStart {
 		t.Errorf("NewCore did not error correctly:\ngot\n%s\nwant\n%s", got, utils.ErrEndBeforeStart)
+	}
+}
+
+func TestGetRandomSubsetPerm(t *testing.T) {
+	cases := []struct {
+		scale  int
+		nItems int
+	}{
+		{scale: 10, nItems: 0},
+		{scale: 10, nItems: 1},
+		{scale: 10, nItems: 5},
+		{scale: 10, nItems: 10},
+		{scale: 1000, nItems: 1000},
+	}
+
+	for _, c := range cases {
+		ret, err := GetRandomSubsetPerm(c.nItems, c.scale)
+		if err != nil {
+			t.Fatalf("unexpected error: got %v", err)
+		}
+		if len(ret) != c.nItems {
+			t.Errorf("return list not long enough: got %d want %d (scale %d)", len(ret), c.nItems, c.scale)
+		}
+		sort.Ints(ret)
+		prev := -1
+		for _, x := range ret {
+			if x == prev {
+				t.Errorf("duplicate int found in sorted result (scale %d nItems %d)", c.scale, c.nItems)
+			}
+			prev = x
+		}
+	}
+}
+
+func TestGetRandomSubsetPermError(t *testing.T) {
+	ret, err := GetRandomSubsetPerm(11, 10)
+	if ret != nil {
+		t.Errorf("return was non-nil: %v", ret)
+	}
+	if got := err.Error(); got != errMoreItemsThanScale {
+		t.Errorf("incorrect output:\ngot\n%s\nwant\n%s", got, errMoreItemsThanScale)
 	}
 }

--- a/cmd/tsbs_generate_queries/uses/devops/common.go
+++ b/cmd/tsbs_generate_queries/uses/devops/common.go
@@ -2,7 +2,6 @@ package devops
 
 import (
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/common"
@@ -14,7 +13,6 @@ const (
 	errNHostsCannotNegative = "nHosts cannot be negative"
 	errNoMetrics            = "cannot get 0 metrics"
 	errTooManyMetrics       = "too many metrics asked for"
-	errMoreItemsThanScale   = "cannot get random permutation with more items than scale"
 
 	// TableName is the name of the table where the time series data is stored for devops use case.
 	TableName = "cpu"
@@ -156,7 +154,7 @@ func getRandomHosts(numHosts int, totalHosts int) ([]string, error) {
 		return nil, fmt.Errorf("number of hosts (%d) larger than total hosts. See --scale (%d)", numHosts, totalHosts)
 	}
 
-	randomNumbers, err := getRandomSubsetPerm(numHosts, totalHosts)
+	randomNumbers, err := common.GetRandomSubsetPerm(numHosts, totalHosts)
 	if err != nil {
 		return nil, err
 	}
@@ -167,31 +165,4 @@ func getRandomHosts(numHosts int, totalHosts int) ([]string, error) {
 	}
 
 	return hostnames, nil
-}
-
-// getRandomSubsetPerm returns a subset of numItems of a permutation of numbers from 0 to totalNumbers,
-// e.g., 5 items out of 30. This is an alternative to rand.Perm and then taking a sub-slice,
-// which used up a lot more memory and slowed down query generation significantly.
-// The subset of the permutation should have no duplicates and thus, can not be longer that original set
-// Ex.: 12, 7, 25 for numItems=3 and totalItems=30 (3 out of 30)
-func getRandomSubsetPerm(numItems int, totalItems int) ([]int, error) {
-	if numItems > totalItems {
-		// Cannot make a subset longer than the original set
-		return nil, fmt.Errorf(errMoreItemsThanScale)
-	}
-
-	seen := map[int]bool{}
-	res := []int{}
-	for i := 0; i < numItems; i++ {
-		for {
-			n := rand.Intn(totalItems)
-			// Keep iterating until a previously unseen int is found
-			if !seen[n] {
-				seen[n] = true
-				res = append(res, n)
-				break
-			}
-		}
-	}
-	return res, nil
 }

--- a/cmd/tsbs_generate_queries/uses/devops/common_test.go
+++ b/cmd/tsbs_generate_queries/uses/devops/common_test.go
@@ -3,7 +3,6 @@ package devops
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -267,46 +266,5 @@ func TestGetMaxAllLabel(t *testing.T) {
 	got := GetMaxAllLabel("Foo", 100)
 	if got != want {
 		t.Errorf("incorrect output: got %s want %s", got, want)
-	}
-}
-
-func TestGetRandomSubsetPerm(t *testing.T) {
-	cases := []struct {
-		scale  int
-		nItems int
-	}{
-		{scale: 10, nItems: 0},
-		{scale: 10, nItems: 1},
-		{scale: 10, nItems: 5},
-		{scale: 10, nItems: 10},
-		{scale: 1000, nItems: 1000},
-	}
-
-	for _, c := range cases {
-		ret, err := getRandomSubsetPerm(c.nItems, c.scale)
-		if err != nil {
-			t.Fatalf("unexpected error: got %v", err)
-		}
-		if len(ret) != c.nItems {
-			t.Errorf("return list not long enough: got %d want %d (scale %d)", len(ret), c.nItems, c.scale)
-		}
-		sort.Ints(ret)
-		prev := -1
-		for _, x := range ret {
-			if x == prev {
-				t.Errorf("duplicate int found in sorted result (scale %d nItems %d)", c.scale, c.nItems)
-			}
-			prev = x
-		}
-	}
-}
-
-func TestGetRandomSubsetPermError(t *testing.T) {
-	ret, err := getRandomSubsetPerm(11, 10)
-	if ret != nil {
-		t.Errorf("return was non-nil: %v", ret)
-	}
-	if got := err.Error(); got != errMoreItemsThanScale {
-		t.Errorf("incorrect output:\ngot\n%s\nwant\n%s", got, errMoreItemsThanScale)
 	}
 }

--- a/cmd/tsbs_generate_queries/uses/iot/lastloc_single_truck.go
+++ b/cmd/tsbs_generate_queries/uses/iot/lastloc_single_truck.go
@@ -1,0 +1,29 @@
+package iot
+
+import (
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/common"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
+	"github.com/timescale/tsbs/query"
+)
+
+// LastLocSingleTruck contains info for filling in last location query for a single truck.
+type LastLocSingleTruck struct {
+	core utils.QueryGenerator
+}
+
+// NewLastLocSingleTruck creates a new last location query filler.
+func NewLastLocSingleTruck(core utils.QueryGenerator) utils.QueryFiller {
+	return &LastLocSingleTruck{
+		core: core,
+	}
+}
+
+// Fill fills in the query.Query with query details.
+func (i *LastLocSingleTruck) Fill(q query.Query) query.Query {
+	fc, ok := i.core.(LastLocByTruckFiller)
+	if !ok {
+		common.PanicUnimplementedQuery(i.core)
+	}
+	fc.LastLocByTruck(q, 1)
+	return q
+}


### PR DESCRIPTION
The new query fetches the last location of a single truck referenced by the
truck name. Truck name will be generated randomly from the scale which
represent the number of trucks currently available.