### PR TITLE
Fix InfluxDB query group by time

### DIFF
--- a/cmd/tsbs_generate_queries/databases/influx/devops.go
+++ b/cmd/tsbs_generate_queries/databases/influx/devops.go
@@ -111,7 +111,7 @@ func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
 
 	humanLabel := devops.GetMaxAllLabel("Influx", nHosts)
 	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
-	influxql := fmt.Sprintf("SELECT %s from cpu where %s and time >= '%s' and time < '%s' group by time(1m)", strings.Join(selectClauses, ","), whereHosts, interval.StartString(), interval.EndString())
+	influxql := fmt.Sprintf("SELECT %s from cpu where %s and time >= '%s' and time < '%s' group by time(1h)", strings.Join(selectClauses, ","), whereHosts, interval.StartString(), interval.EndString())
 	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
 }
 

--- a/cmd/tsbs_generate_queries/databases/influx/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/influx/devops_test.go
@@ -251,7 +251,7 @@ func TestMaxAllCPU(t *testing.T) {
 				"from cpu " +
 				"where (hostname = 'host_3') and " +
 				"time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T08:54:10Z' " +
-				"group by time(1m)",
+				"group by time(1h)",
 		},
 		{
 			desc:               "5 hosts",
@@ -263,7 +263,7 @@ func TestMaxAllCPU(t *testing.T) {
 				"from cpu " +
 				"where (hostname = 'host_9' or hostname = 'host_5' or hostname = 'host_1' or hostname = 'host_7' or hostname = 'host_2') " +
 				"and time >= '1970-01-01T00:37:12Z' and time < '1970-01-01T08:37:12Z' " +
-				"group by time(1m)",
+				"group by time(1h)",
 		},
 	}
 


### PR DESCRIPTION
Compared to the description of MaxAllCPU and how queries against
other databases were implemented, the InfluxDB implementation grouped
by minutes instead of hours.