### PR TITLE
Update float value precision for generated IoT use case data

### DIFF
--- a/cmd/tsbs_generate_data/common/distribution.go
+++ b/cmd/tsbs_generate_data/common/distribution.go
@@ -175,3 +175,34 @@ func (d *ConstantDistribution) Advance() {
 func (d *ConstantDistribution) Get() float64 {
 	return d.State
 }
+
+// FloatPrecision is a distribution wrapper which specifies the float value precision of the underlying distribution.
+type FloatPrecision struct {
+	step      Distribution
+	precision float64
+}
+
+// Advance calls the underlying distribution Advance method.
+func (f *FloatPrecision) Advance() {
+	f.step.Advance()
+}
+
+// Get returns the value from the underlying distribution with adjusted float value precision.
+func (f *FloatPrecision) Get() float64 {
+	return float64(int(f.step.Get()*f.precision)) / f.precision
+}
+
+// FP creates a new FloatPrecision distribution wrapper with a given distribution and precision value.
+// Precision value is clamped to [0,5] to avoid floating point calculation errors.
+func FP(step Distribution, precision int) *FloatPrecision {
+	// Clamping the precision value to spec.
+	if precision < 0 {
+		precision = 0
+	} else if precision > 5 {
+		precision = 5
+	}
+	return &FloatPrecision{
+		step:      step,
+		precision: math.Pow(10, float64(precision)),
+	}
+}

--- a/cmd/tsbs_generate_data/common/distribution_test.go
+++ b/cmd/tsbs_generate_data/common/distribution_test.go
@@ -1,0 +1,98 @@
+package common
+
+import (
+	"math"
+	"testing"
+)
+
+type mockDistribution struct {
+	AdvanceCalled bool
+	ReturnValue   float64
+}
+
+func (m *mockDistribution) Advance() {
+	m.AdvanceCalled = true
+}
+
+func (m *mockDistribution) Get() float64 {
+	return m.ReturnValue
+}
+
+func TestFloatPrecisionAdvance(t *testing.T) {
+
+	dist := &mockDistribution{}
+
+	fp := FP(dist, 1)
+
+	fp.Advance()
+
+	if !dist.AdvanceCalled {
+		t.Errorf("FloatPrecision Advance call did not call underlying distribution Advance method")
+	}
+}
+
+func TestFloatPrecisionGet(t *testing.T) {
+	testCases := []struct {
+		value   float64
+		results map[int]float64
+	}{
+		{
+			value: 1.234567890,
+			results: map[int]float64{
+				-1: 1,
+				0:  1,
+				1:  1.2,
+				2:  1.23,
+				3:  1.234,
+				4:  1.2345,
+				5:  1.23456,
+				6:  1.23456,
+				7:  1.23456,
+				8:  1.23456,
+				9:  1.23456,
+			},
+		},
+		{
+			value: 1.0,
+			results: map[int]float64{
+				-1: 1,
+				0:  1,
+				1:  1.0,
+				2:  1.00,
+				3:  1.000,
+				4:  1.0000,
+				5:  1.00000,
+				6:  1.00000,
+				7:  1.00000,
+				8:  1.00000,
+				9:  1.00000,
+			},
+		},
+		{
+			value: 0.0,
+			results: map[int]float64{
+				-1: 0,
+				0:  0,
+				1:  0.0,
+				2:  0.00,
+				3:  0.000,
+				4:  0.0000,
+				5:  0.00000,
+				6:  0.00000,
+				7:  0.00000,
+				8:  0.00000,
+				9:  0.00000,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		for precision, want := range testCase.results {
+			fp := FP(&mockDistribution{ReturnValue: testCase.value}, precision)
+
+			if got := fp.Get(); got != want {
+				t.Errorf("wrong result for value %f and precision %d, got %f want %f (diff %f)", testCase.value, precision, got, want, math.Abs(got-want))
+			}
+		}
+	}
+}

--- a/cmd/tsbs_generate_data/iot/diagnostics.go
+++ b/cmd/tsbs_generate_data/iot/diagnostics.go
@@ -24,16 +24,31 @@ var (
 
 	diagnosticsFields = []common.LabeledDistributionMaker{
 		{
-			Label:             labelFuelState,
-			DistributionMaker: func() common.Distribution { return &customFuelDistribution{common.CWD(fuelUD, 0, maxFuel, maxFuel)} },
+			Label: labelFuelState,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					&customFuelDistribution{common.CWD(fuelUD, 0, maxFuel, maxFuel)},
+					1,
+				)
+			},
 		},
 		{
-			Label:             labelCurrentLoad,
-			DistributionMaker: func() common.Distribution { return common.CWD(loadND, 0, maxLoad, rand.Float64()*maxLoad) },
+			Label: labelCurrentLoad,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(loadND, 0, maxLoad, rand.Float64()*maxLoad),
+					0,
+				)
+			},
 		},
 		{
-			Label:             labelStatus,
-			DistributionMaker: func() common.Distribution { return common.CWD(statusND, 0, 5, 0) },
+			Label: labelStatus,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(statusND, 0, 5, 0),
+					0,
+				)
+			},
 		},
 	}
 )

--- a/cmd/tsbs_generate_data/iot/readings.go
+++ b/cmd/tsbs_generate_data/iot/readings.go
@@ -34,32 +34,67 @@ var (
 
 	readingsFields = []common.LabeledDistributionMaker{
 		{
-			Label:             labelLatitude,
-			DistributionMaker: func() common.Distribution { return common.CWD(geoStepUD, -90.0, 90.0, rand.NormFloat64()*maxLatitude) },
+			Label: labelLatitude,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(geoStepUD, -90.0, 90.0, rand.Float64()*maxLatitude),
+					5,
+				)
+			},
 		},
 		{
-			Label:             labelLongitude,
-			DistributionMaker: func() common.Distribution { return common.CWD(geoStepUD, -180, 180, rand.NormFloat64()*maxLongitude) },
+			Label: labelLongitude,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(geoStepUD, -180, 180, rand.Float64()*maxLongitude),
+					5,
+				)
+			},
 		},
 		{
-			Label:             labelElevation,
-			DistributionMaker: func() common.Distribution { return common.CWD(bigUD, 0, maxElevation, rand.Float64()*500) },
+			Label: labelElevation,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(bigUD, 0, maxElevation, rand.Float64()*500),
+					0,
+				)
+			},
 		},
 		{
-			Label:             labelVelocity,
-			DistributionMaker: func() common.Distribution { return common.CWD(bigUD, 0, maxVelocity, 0) },
+			Label: labelVelocity,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(bigUD, 0, maxVelocity, 0),
+					0,
+				)
+			},
 		},
 		{
-			Label:             labelHeading,
-			DistributionMaker: func() common.Distribution { return common.CWD(smallUD, 0, maxHeading, rand.Float64()*maxHeading) },
+			Label: labelHeading,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(smallUD, 0, maxHeading, rand.Float64()*maxHeading),
+					0,
+				)
+			},
 		},
 		{
-			Label:             labelGrade,
-			DistributionMaker: func() common.Distribution { return common.CWD(smallUD, 0, maxGrade, 0) },
+			Label: labelGrade,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(smallUD, 0, maxGrade, 0),
+					0,
+				)
+			},
 		},
 		{
-			Label:             labelFuelConsumption,
-			DistributionMaker: func() common.Distribution { return common.CWD(smallUD, 0, maxFuelConsumption, maxFuelConsumption/2) },
+			Label: labelFuelConsumption,
+			DistributionMaker: func() common.Distribution {
+				return common.FP(
+					common.CWD(smallUD, 0, maxFuelConsumption, maxFuelConsumption/2),
+					1,
+				)
+			},
 		},
 	}
 )


### PR DESCRIPTION
Previously, floating point precision was unbounded. This commit
introduces some sensible precision limits to better emulate real world
data.