### PR TITLE
Reduce the variability in a Truck's Load in IoT

### DIFF
--- a/cmd/tsbs_generate_data/common/distribution.go
+++ b/cmd/tsbs_generate_data/common/distribution.go
@@ -206,3 +206,36 @@ func FP(step Distribution, precision int) *FloatPrecision {
 		precision: math.Pow(10, float64(precision)),
 	}
 }
+
+// LazyDistribution is a distribution that can change it's value
+// only if a "motivation" distribution provides a value above a specified threshold.
+// Otherwise it remains the same.
+type LazyDistribution struct {
+	motive    Distribution
+	step      Distribution
+	threshold float64
+}
+
+// LD returns a new LazyDistribution that returns a new value from "dist", if the "motavation" distribution,
+// fires above the threshold.
+func LD(motive, dist Distribution, threshold float64) *LazyDistribution {
+	return &LazyDistribution{
+		step:      dist,
+		motive:    motive,
+		threshold: threshold,
+	}
+}
+
+// Advance computes the next value of this distribution.
+func (d *LazyDistribution) Advance() {
+	d.motive.Advance()
+	if d.motive.Get() < d.threshold {
+		return
+	}
+	d.step.Advance()
+}
+
+// Get returns the last computed value for this distribution.
+func (d *LazyDistribution) Get() float64 {
+	return d.step.Get()
+}

--- a/cmd/tsbs_generate_data/iot/diagnostics.go
+++ b/cmd/tsbs_generate_data/iot/diagnostics.go
@@ -1,7 +1,6 @@
 package iot
 
 import (
-	"math/rand"
 	"time"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_data/common"
@@ -9,8 +8,9 @@ import (
 )
 
 const (
-	maxFuel = 1.0
-	maxLoad = 5000.0
+	maxFuel          = 1.0
+	maxLoad          = 5000.0
+	loadChangeChance = 0.05
 )
 
 var (
@@ -19,7 +19,8 @@ var (
 	labelCurrentLoad = []byte("current_load")
 	labelStatus      = []byte("status")
 	fuelUD           = common.UD(-0.001, 0)
-	loadND           = common.ND(0, 1)
+	loadUD           = common.UD(0, maxLoad)
+	loadSaddleUD     = common.UD(0, 1)
 	statusND         = common.ND(0, 1)
 
 	diagnosticsFields = []common.LabeledDistributionMaker{
@@ -36,7 +37,7 @@ var (
 			Label: labelCurrentLoad,
 			DistributionMaker: func() common.Distribution {
 				return common.FP(
-					common.CWD(loadND, 0, maxLoad, rand.Float64()*maxLoad),
+					common.LD(loadSaddleUD, loadUD, 1-loadChangeChance),
 					0,
 				)
 			},


### PR DESCRIPTION
A truck's current load diagnostic was changing too much between measurements.
This change introduces a SaddledDistribution. A distribution that will change it's 
value only if a random value goes over a given threshold. 