### PR TITLE
Fix the way to set flags in scripts due to switching to viper lib

### DIFF
--- a/scripts/full_cycle_minitest_clickhouse.sh
+++ b/scripts/full_cycle_minitest_clickhouse.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-$GOPATH/bin/tsbs_generate_data -format clickhouse -use-case cpu-only -scale 10 -seed 123 -file /tmp/bulk_data/clickhouse_data
+$GOPATH/bin/tsbs_generate_data --format clickhouse --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/clickhouse_data
 
-$GOPATH/bin/tsbs_generate_queries -format clickhouse -use-case cpu-only -scale 10 -seed 123 -query-type lastpoint     -file /tmp/bulk_data/clickhouse_query_lastpoint
-$GOPATH/bin/tsbs_generate_queries -format clickhouse -use-case cpu-only -scale 10 -seed 123 -query-type cpu-max-all-1 -file /tmp/bulk_data/clickhouse_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries -format clickhouse -use-case cpu-only -scale 10 -seed 123 -query-type high-cpu-1    -file /tmp/bulk_data/clickhouse_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/clickhouse_query_lastpoint
+$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/clickhouse_query_cpu-max-all-1
+$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/clickhouse_query_high-cpu-1
 
 $GOPATH/bin/tsbs_load_clickhouse --db-name=benchmark --host=127.0.0.1 --workers=1 --file=/tmp/bulk_data/clickhouse_data
 

--- a/scripts/full_cycle_minitest_cratedb.sh
+++ b/scripts/full_cycle_minitest_cratedb.sh
@@ -2,14 +2,14 @@
 
 # generate data
 mkdir -p /tmp/bulk_data
-$GOPATH/bin/tsbs_generate_data -format cratedb -use-case cpu-only -scale 10 -seed 123 -file /tmp/bulk_data/cratedb_data
+$GOPATH/bin/tsbs_generate_data --format cratedb --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/cratedb_data
 
 # generate queries
-$GOPATH/bin/tsbs_generate_queries -format cratedb -use-case cpu-only -scale 10 -seed 123 -query-type lastpoint             -file /tmp/bulk_data/cratedb_query_lastpoint
-$GOPATH/bin/tsbs_generate_queries -format cratedb -use-case cpu-only -scale 10 -seed 123 -query-type cpu-max-all-1         -file /tmp/bulk_data/cratedb_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries -format cratedb -use-case cpu-only -scale 10 -seed 123 -query-type high-cpu-1            -file /tmp/bulk_data/cratedb_query_high-cpu-1
-$GOPATH/bin/tsbs_generate_queries -format cratedb -use-case cpu-only -scale 10 -seed 123 -query-type single-groupby-5-1-1  -file /tmp/bulk_data/cratedb_query_single-groupby-5-1-1
-$GOPATH/bin/tsbs_generate_queries -format cratedb -use-case cpu-only -scale 10 -seed 123 -query-type groupby-orderby-limit -file /tmp/bulk_data/cratedb_query_groupby-orderby-limit
+$GOPATH/bin/tsbs_generate_queries --format cratedb --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint             --file /tmp/bulk_data/cratedb_query_lastpoint
+$GOPATH/bin/tsbs_generate_queries --format cratedb --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1         --file /tmp/bulk_data/cratedb_query_cpu-max-all-1
+$GOPATH/bin/tsbs_generate_queries --format cratedb --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1            --file /tmp/bulk_data/cratedb_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --format cratedb --use-case cpu-only --scale 10 --seed 123 --query-type single-groupby-5-1-1  --file /tmp/bulk_data/cratedb_query_single-groupby-5-1-1
+$GOPATH/bin/tsbs_generate_queries --format cratedb --use-case cpu-only --scale 10 --seed 123 --query-type groupby-orderby-limit --file /tmp/bulk_data/cratedb_query_groupby-orderby-limit
 
 # insert benchmark
 $GOPATH/bin/tsbs_load_cratedb --db-name=benchmark --hosts=localhost --workers=1 --file=/tmp/bulk_data/cratedb_data

--- a/scripts/full_cycle_minitest_timescaledb.sh
+++ b/scripts/full_cycle_minitest_timescaledb.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-$GOPATH/bin/tsbs_generate_data -format timescaledb -use-case cpu-only -scale 10 -seed 123 -file /tmp/bulk_data/timescaledb_data
+$GOPATH/bin/tsbs_generate_data --format timescaledb --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/timescaledb_data
 
-$GOPATH/bin/tsbs_generate_queries -format timescaledb -use-case cpu-only -scale 10 -seed 123 -query-type lastpoint     -file /tmp/bulk_data/timescaledb_query_lastpoint
-$GOPATH/bin/tsbs_generate_queries -format timescaledb -use-case cpu-only -scale 10 -seed 123 -query-type cpu-max-all-1 -file /tmp/bulk_data/timescaledb_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries -format timescaledb -use-case cpu-only -scale 10 -seed 123 -query-type high-cpu-1    -file /tmp/bulk_data/timescaledb_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/timescaledb_query_lastpoint
+$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/timescaledb_query_cpu-max-all-1
+$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/timescaledb_query_high-cpu-1
 
 $GOPATH/bin/tsbs_load_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
 

--- a/scripts/generate_data.sh
+++ b/scripts/generate_data.sh
@@ -53,14 +53,14 @@ for FORMAT in ${FORMATS}; do
 
         echo "Generating ${DATA_FILE_NAME}:"
         ${EXE_FILE_NAME} \
-            -format ${FORMAT} \
-            -use-case ${USE_CASE} \
-            -scale ${SCALE} \
-            -timestamp-start ${TS_START} \
-            -timestamp-end ${TS_END} \
-            -seed ${SEED} \
-            -log-interval ${LOG_INTERVAL} \
-            -max-data-points ${MAX_DATA_POINTS} \
+            --format ${FORMAT} \
+            --use-case ${USE_CASE} \
+            --scale ${SCALE} \
+            --timestamp-start ${TS_START} \
+            --timestamp-end ${TS_END} \
+            --seed ${SEED} \
+            --log-interval ${LOG_INTERVAL} \
+            --max-data-points ${MAX_DATA_POINTS} \
         | gzip > ${DATA_FILE_NAME}
 
         trap - EXIT

--- a/scripts/generate_queries.sh
+++ b/scripts/generate_queries.sh
@@ -78,18 +78,18 @@ for QUERY_TYPE in ${QUERY_TYPES}; do
 
             echo "Generating ${DATA_FILE_NAME}:"
             ${EXE_FILE_NAME} \
-                -format ${FORMAT} \
-                -queries ${QUERIES} \
-                -query-type ${QUERY_TYPE} \
-                -scale ${SCALE} \
-                -seed ${SEED} \
-                -timestamp-start ${TS_START} \
-                -timestamp-end ${TS_END} \
-                -use-case ${USE_CASE} \
-                -timescale-use-json=${USE_JSON} \
-                -timescale-use-tags=${USE_TAGS} \
-                -timescale-use-time-bucket=${USE_TIME_BUCKET} \
-                -clickhouse-use-tags=${USE_TAGS} \
+                --format ${FORMAT} \
+                --queries ${QUERIES} \
+                --query-type ${QUERY_TYPE} \
+                --scale ${SCALE} \
+                --seed ${SEED} \
+                --timestamp-start ${TS_START} \
+                --timestamp-end ${TS_END} \
+                --use-case ${USE_CASE} \
+                --timescale-use-json=${USE_JSON} \
+                --timescale-use-tags=${USE_TAGS} \
+                --timescale-use-time-bucket=${USE_TIME_BUCKET} \
+                --clickhouse-use-tags=${USE_TAGS} \
             | gzip  > ${DATA_FILE_NAME}
 
             trap - EXIT

--- a/scripts/run_queries_clickhouse.sh
+++ b/scripts/run_queries_clickhouse.sh
@@ -43,8 +43,8 @@ function run_file()
     cat $FULL_DATA_FILE_NAME \
         | $GUNZIP \
         | $EXE_FILE_NAME \
-            -max-queries $MAX_QUERIES \
-            -workers $NUM_WORKERS \
+            --max-queries $MAX_QUERIES \
+            --workers $NUM_WORKERS \
         | tee $OUT_FULL_FILE_NAME
 }
 

--- a/scripts/run_queries_influx.sh
+++ b/scripts/run_queries_influx.sh
@@ -44,8 +44,8 @@ function run_file()
     cat $FULL_DATA_FILE_NAME \
         | $GUNZIP \
         | $EXE_FILE_NAME \
-            -max-queries $MAX_QUERIES \
-            -workers $NUM_WORKERS \
+            --max-queries $MAX_QUERIES \
+            --workers $NUM_WORKERS \
         | tee $OUT_FULL_FILE_NAME
 }
 

--- a/scripts/run_queries_mongo.sh
+++ b/scripts/run_queries_mongo.sh
@@ -44,8 +44,8 @@ function run_file()
     cat $FULL_DATA_FILE_NAME \
         | $GUNZIP \
         | $EXE_FILE_NAME \
-            -max-queries $MAX_QUERIES \
-            -workers $NUM_WORKERS \
+            --max-queries $MAX_QUERIES \
+            --workers $NUM_WORKERS \
         | tee $OUT_FULL_FILE_NAME
 }
 

--- a/scripts/run_queries_siridb.sh
+++ b/scripts/run_queries_siridb.sh
@@ -57,10 +57,10 @@ function run_file()
     cat $FULL_DATA_FILE_NAME \
         | $GUNZIP \
         | $EXE_FILE_NAME \
-            -max-queries $MAX_QUERIES \
-            -workers $NUM_WORKERS \
-            -scale $SCALE \
-            -query-limit $QUERY_LIMIT \
+            --max-queries $MAX_QUERIES \
+            --workers $NUM_WORKERS \
+            --scale $SCALE \
+            --query-limit $QUERY_LIMIT \
         | tee $OUT_FULL_FILE_NAME
 }
 

--- a/scripts/run_queries_timescaledb.sh
+++ b/scripts/run_queries_timescaledb.sh
@@ -46,7 +46,7 @@ for FULL_DATA_FILE_NAME in ${BULK_DATA_DIR}/queries_timescaledb*; do
     cat $FULL_DATA_FILE_NAME \
         | $GUNZIP \
         | $EXE_FILE_NAME \
-            -max-queries $MAX_QUERIES \
-            -workers $NUM_WORKERS \
+            --max-queries $MAX_QUERIES \
+            --workers $NUM_WORKERS \
         | tee $OUT_FULL_FILE_NAME
 done


### PR DESCRIPTION
Since flag parse lib was changed to viper - old way for passing flags in scripts doesn't work:
```
FORMATS=timescaledb ./scripts/generate_data.sh
Generating data_timescaledb_cpu-only_4000_2019-09-01T00:00:00Z_2019-09-03T00:00:00Z_10s_123.dat.gz:
unknown shorthand flag: 'f' in -format
```

 This PR supposed to set the same way for passing flags for all scripts.