### PR TITLE
Add ability to build Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+ARG GO_VERSION=1.13.1
+FROM golang:${GO_VERSION}-alpine
+
+ARG TSBS_VERSION=master
+RUN apk update && apk add --no-cache --virtual .build-deps git \
+    && mkdir -p ${GOPATH}/src/github.com/timescale/ \
+    && cd ${GOPATH}/src/github.com/timescale/ \
+    && git clone --depth=1 --branch ${TSBS_VERSION} https://github.com/timescale/tsbs.git \
+    && cd $GOPATH/src/github.com/timescale/tsbs \
+    && go get -d -v ./... \
+    && go build -o /go/bin/ ./... \
+    && rm -rf $GOPATH/src/github.com/timescale/tsbs \
+    && apk del .build-deps

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/timescale/tsbs
 
-go 1.12
+go 1.13
 
 require (
 	github.com/SiriDB/go-siridb-connector v0.0.0-20190110105621-86b34c44c921


### PR DESCRIPTION
This change adds a Dockerfile to build a Docker image for TSBS. This
makes it easier for people to quickly test TSBS and run benchmarks on, e.g., Kubernetes.

This also bumps Go modules to depend on Go 1.13.