### PR TITLE
enable full percentile spectrum analysis on latency. enable maintaining fixed rps during query benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 .idea
 .vscode
+
+# High Dynamic Range (HDR) Histogram files
+*.hdr

--- a/query/benchmarker_test.go
+++ b/query/benchmarker_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -38,7 +39,7 @@ func TestProcessorHandler(t *testing.T) {
 	var wg sync.WaitGroup
 	qPool := &testQueryPool
 	wg.Add(2)
-	var requestRate = rate.Limit(math.MaxFloat64)
+	var requestRate = rate.Inf
 	var requestBurst = 0
 	var rateLimiter *rate.Limiter = rate.NewLimiter(requestRate, requestBurst)
 
@@ -75,7 +76,7 @@ func TestProcessorHandlerPreWarm(t *testing.T) {
 		limit:          &b.Limit,
 		prewarmQueries: true,
 	}
-	var requestRate = rate.Limit(math.MaxFloat64)
+	var requestRate = rate.Inf
 	var requestBurst = 0
 	var rateLimiter *rate.Limiter = rate.NewLimiter(requestRate, requestBurst)
 
@@ -334,4 +335,28 @@ type mockProcessor struct {
 func (mp *mockProcessor) Init(workerNum int) { mp.initCalled = true }
 func (mp *mockProcessor) ProcessQuery(q Query, isWarm bool) ([]*Stat, error) {
 	return mp.processRes, mp.processErr
+}
+
+func Test_getRateLimiter(t *testing.T) {
+	type args struct {
+		limitRPS uint64
+		workers  uint
+	}
+	tests := []struct {
+		name 	   string
+		args 	   args
+		wantLimit  float64
+		wantBurst  int
+	}{
+	{"zero limit", args{0,8}, math.MaxFloat64,0 },
+	{"8 burst", args{300,8}, 300.0,8 },
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limiter := getRateLimiter(tt.args.limitRPS, tt.args.workers)
+			if gotBurst := limiter.Burst(); !reflect.DeepEqual(gotBurst, tt.wantBurst) {
+				t.Errorf("getRateLimiter() Burst got = %v, want %v", gotBurst, tt.wantBurst)
+			}
+		})
+	}
 }

--- a/query/benchmarker_test.go
+++ b/query/benchmarker_test.go
@@ -156,6 +156,8 @@ func TestBenchmarkRunnerGetBufferedReaderCached(t *testing.T) {
 	b.GetBufferedReader()
 }
 
+
+
 func TestBenchmarkRunnerRunPanicOnNoWorkers(t *testing.T) {
 	runner := &BenchmarkRunner{}
 	defer func() {

--- a/query/benchmarker_test.go
+++ b/query/benchmarker_test.go
@@ -337,7 +337,7 @@ func (mp *mockProcessor) ProcessQuery(q Query, isWarm bool) ([]*Stat, error) {
 	return mp.processRes, mp.processErr
 }
 
-func Test_getRateLimiter(t *testing.T) {
+func TestGetRateLimiter(t *testing.T) {
 	type args struct {
 		limitRPS uint64
 		workers  uint

--- a/query/benchmarker_test.go
+++ b/query/benchmarker_test.go
@@ -79,7 +79,7 @@ func TestProcessorHandlerPreWarm(t *testing.T) {
 	var requestBurst = 0
 	var rateLimiter *rate.Limiter = rate.NewLimiter(requestRate, requestBurst)
 
-	b.sp = newStatProcessor(spArgs, "")
+	b.sp = newStatProcessor(spArgs)
 	b.ch = make(chan Query, 2)
 	var wg sync.WaitGroup
 	qPool := &testQueryPool
@@ -313,7 +313,7 @@ func (m *mockStatProcessor) sendWarm(stats []*Stat) {
 		m.onSend(stats)
 	}
 }
-func (m *mockStatProcessor) process(workers uint, latencyFile string) {
+func (m *mockStatProcessor) process(workers uint) {
 	if m.onProcess != nil {
 		m.onProcess(workers)
 	}

--- a/query/stat_processor.go
+++ b/query/stat_processor.go
@@ -172,8 +172,8 @@ func (sp *defaultStatProcessor) process(workers uint) {
 		_, _ = fmt.Printf("Saving High Dynamic Range (HDR) Histogram of Response Latencies to %s\n", sp.args.hdrLatenciesFile)
 
 		d1 := []byte(statMapping[allQueriesLabel].latencyHDRHistogram.PercentilesPrint(10, 1000.0))
-		fErr := ioutil.WriteFile(sp.args.hdrLatenciesFile, d1, 0644)
-		if fErr != nil {
+		err = ioutil.WriteFile(sp.args.hdrLatenciesFile, d1, 0644)
+		if err != nil {
 			log.Fatal(err)
 		}
 

--- a/query/stat_processor.go
+++ b/query/stat_processor.go
@@ -47,10 +47,6 @@ func (sp *defaultStatProcessor) getArgs() *statProcessorArgs {
 	return sp.args
 }
 
-func (sp *defaultStatProcessor) getStatsMapping() *statProcessorArgs {
-	return sp.args
-}
-
 func (sp *defaultStatProcessor) send(stats []*Stat) {
 	if stats == nil {
 		return

--- a/query/stats.go
+++ b/query/stats.go
@@ -78,11 +78,6 @@ func newStatGroup(size uint64) *statGroup {
 	}
 }
 
-// median returns the median value of the StatGroup in milliseconds
-func (s *statGroup) median() float64 {
-	return float64(s.latencyHDRHistogram.ValueAtQuantile(50.0))/10e2
-}
-
 // push updates a StatGroup with a new value.
 func (s *statGroup) push(n float64) {
 	s.latencyHDRHistogram.RecordValue(int64(n * 10e2))
@@ -93,11 +88,11 @@ func (s *statGroup) push(n float64) {
 // string makes a simple description of a statGroup.
 func (s *statGroup) string() string {
 	return fmt.Sprintf("min: %8.2fms, med: %8.2fms, mean: %8.2fms, max: %7.2fms, stddev: %8.2fms, sum: %5.1fsec, count: %d",
-		float64(s.latencyHDRHistogram.Min())/10e2,
-		s.median(),
-		float64(s.latencyHDRHistogram.Mean())/10e2,
-		float64(s.latencyHDRHistogram.Max())/10e2,
-		float64(s.latencyHDRHistogram.StdDev())/10e2,
+		s.Min(),
+		s.Median(),
+		s.Mean(),
+		s.Max(),
+		s.StdDev(),
 		s.sum/1e3,
 		s.count)
 }
@@ -107,16 +102,29 @@ func (s *statGroup) write(w io.Writer) error {
 	return err
 }
 
+// Median returns the Median value of the StatGroup in milliseconds
+func (s *statGroup) Median() float64 {
+	return float64(s.latencyHDRHistogram.ValueAtQuantile(50.0))/10e2
+}
+
+// Mean returns the Mean value of the StatGroup in milliseconds
 func (s *statGroup) Mean() float64 {
 	return float64(s.latencyHDRHistogram.Mean())/10e2
 }
 
+// Max returns the Max value of the StatGroup in milliseconds
 func (s *statGroup) Max() float64 {
 	return float64(s.latencyHDRHistogram.Max())/10e2
 }
 
+// Min returns the Min value of the StatGroup in milliseconds
 func (s *statGroup) Min() float64 {
 	return float64(s.latencyHDRHistogram.Min())/10e2
+}
+
+// StdDev returns the StdDev value of the StatGroup in milliseconds
+func (s *statGroup) StdDev() float64 {
+	return float64(s.latencyHDRHistogram.StdDev())/10e2
 }
 
 // writeStatGroupMap writes a map of StatGroups in an ordered fashion by

--- a/query/stats.go
+++ b/query/stats.go
@@ -59,7 +59,6 @@ func (s *Stat) reset() *Stat {
 type statGroup struct {
 	latencyHDRHistogram *hdrhistogram.Histogram
 	sum    float64
-	values []float64
 	count int64
 }
 
@@ -74,7 +73,6 @@ func newStatGroup(size uint64) *statGroup {
 	//   - 300 microsecond (or better) from 10 seconds up to 30 seconds,
 	lH := hdrhistogram.New(1, 30000000, 4)
 	return &statGroup{
-		values: make([]float64, size),
 		count:  0,
 		latencyHDRHistogram: lH,
 	}
@@ -88,18 +86,6 @@ func (s *statGroup) median() float64 {
 // push updates a StatGroup with a new value.
 func (s *statGroup) push(n float64) {
 	s.latencyHDRHistogram.RecordValue(int64(n * 10e2))
-	if s.count == 0 {
-		s.count = 1
-		s.sum = n
-
-		if len(s.values) > 0 {
-			s.values[0] = n
-		} else {
-			s.values = append(s.values, n)
-		}
-		return
-	}
-
 	s.sum += n
 	s.count++
 }

--- a/query/stats_test.go
+++ b/query/stats_test.go
@@ -78,35 +78,38 @@ func TestStateGroupMedian(t *testing.T) {
 			want: 1.0,
 		},
 		{
-			len:  2,
-			want: 2.0,
-		},
-		{
-			len:  4,
-			want: 4.0,
-		},
-		{
 			len:  5,
 			want: 5.0,
 		},
 		{
-			len:  1000,
-			want: 1000,
+			len:  99,
+			want: 99.0,
+		},
+		{
+			len:  999,
+			want: 999.0,
+		},
+		{
+			len:  9999,
+			want: 9999.0,
 		},
 	}
-
+	errorMargin := 0.0001
 	for _, c := range cases {
 		sg := newStatGroup(c.len)
 		for i := uint64(0); i < c.len; i++ {
 			sg.push(1 + float64(i)*2)
 		}
-		if got := sg.median(); c.want != got {
-			t.Errorf("got: %v want: %v\n", got, c.want)
+		lowerLimit := c.want - (c.want*errorMargin)
+		upperLimit := c.want + (c.want*errorMargin)
+		if got := sg.median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
+			t.Errorf("got: %v want C [ %v,%v ]\n", got, lowerLimit, upperLimit)
 		}
 	}
 }
 
 func TestStatGroupMedian0InitialSize(t *testing.T) {
+	errorMargin := 0.0001
 	cases := []struct {
 		len  uint64
 		want float64
@@ -120,20 +123,20 @@ func TestStatGroupMedian0InitialSize(t *testing.T) {
 			want: 1.0,
 		},
 		{
-			len:  2,
-			want: 2.0,
-		},
-		{
-			len:  4,
-			want: 4.0,
-		},
-		{
 			len:  5,
 			want: 5.0,
 		},
 		{
-			len:  1000,
-			want: 1000,
+			len:  99,
+			want: 99.0,
+		},
+		{
+			len:  999,
+			want: 999.0,
+		},
+		{
+			len:  9999,
+			want: 9999.0,
 		},
 	}
 
@@ -142,8 +145,10 @@ func TestStatGroupMedian0InitialSize(t *testing.T) {
 		for i := uint64(0); i < c.len; i++ {
 			sg.push(1 + float64(i)*2)
 		}
-		if got := sg.median(); c.want != got {
-			t.Errorf("got: %v want: %v\n", got, c.want)
+		lowerLimit := c.want - (c.want*errorMargin)
+		upperLimit := c.want + (c.want*errorMargin)
+		if got := sg.median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
+			t.Errorf("got: %v want C [ %v,%v ]\n", got, lowerLimit, upperLimit)
 		}
 	}
 }
@@ -192,13 +197,13 @@ func TestStatGroupPush(t *testing.T) {
 		for _, val := range c.vals {
 			sg.push(val)
 		}
-		if got := sg.min; got != c.wantMin {
+		if got := sg.Min(); got != c.wantMin {
 			t.Errorf("%s: incorrect min: got %f want %f", c.desc, got, c.wantMin)
 		}
-		if got := sg.max; got != c.wantMax {
+		if got := sg.Max(); got != c.wantMax {
 			t.Errorf("%s: incorrect max: got %f want %f", c.desc, got, c.wantMin)
 		}
-		if got := sg.mean; got != c.wantMean {
+		if got := sg.Mean(); got != c.wantMean {
 			t.Errorf("%s: incorrect mean: got %f want %f", c.desc, got, c.wantMin)
 		}
 		if got := sg.count; got != c.wantCount {

--- a/query/stats_test.go
+++ b/query/stats_test.go
@@ -102,7 +102,7 @@ func TestStateGroupMedian(t *testing.T) {
 		}
 		lowerLimit := c.want - (c.want*errorMargin)
 		upperLimit := c.want + (c.want*errorMargin)
-		if got := sg.median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
+		if got := sg.Median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
 			t.Errorf("got: %v want C [ %v,%v ]\n", got, lowerLimit, upperLimit)
 		}
 	}
@@ -147,7 +147,7 @@ func TestStatGroupMedian0InitialSize(t *testing.T) {
 		}
 		lowerLimit := c.want - (c.want*errorMargin)
 		upperLimit := c.want + (c.want*errorMargin)
-		if got := sg.median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
+		if got := sg.Median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
 			t.Errorf("got: %v want C [ %v,%v ]\n", got, lowerLimit, upperLimit)
 		}
 	}
@@ -160,35 +160,54 @@ func TestStatGroupPush(t *testing.T) {
 		wantMin   float64
 		wantMax   float64
 		wantMean  float64
+		wantMedian  float64
+		wantStdDev  float64
 		wantCount int64
 		wantSum   float64
 	}{
 		{
 			desc:      "ordered smallest to largest",
-			vals:      []float64{0.0, 1.0, 2.0},
-			wantMin:   0.0,
-			wantMax:   2.0,
-			wantMean:  1.0,
-			wantCount: 3,
-			wantSum:   3.0,
+			vals:      []float64{2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0},
+			wantMin:   2.0,
+			wantMax:   9.0,
+			wantMean:  5.0,
+			wantMedian:  4.0,
+			wantStdDev:  2.0,
+			wantCount: 8,
+			wantSum:   40.0,
 		},
 		{
 			desc:      "ordered largest to smallest",
-			vals:      []float64{2.0, 1.0, 0.0},
-			wantMin:   0.0,
-			wantMax:   2.0,
-			wantMean:  1.0,
+			vals:      []float64{9.0, 7.0, 5.0, 5.0, 4.0, 4.0, 4.0, 2.0},
+			wantMin:   2.0,
+			wantMax:   9.0,
+			wantMean:  5.0,
+			wantMedian:  4.0,
+			wantStdDev:  2.0,
+			wantCount: 8,
+			wantSum:   40.0,
+		},
+		{
+			desc:      "no variance",
+			vals:      []float64{10.0, 10.0, 10.0},
+			wantMin:   10.0,
+			wantMax:   10.0,
+			wantMean:  10.0,
+			wantMedian:  10.0,
+			wantStdDev:  0.0,
 			wantCount: 3,
-			wantSum:   3.0,
+			wantSum:   30.0,
 		},
 		{
 			desc:      "out of order",
-			vals:      []float64{17.0, 10.0, 12.0},
-			wantMin:   10.0,
-			wantMax:   17.0,
-			wantMean:  13.0,
-			wantCount: 3,
-			wantSum:   39.0,
+			vals:      []float64{12.0, 10.0, 10.0, 10.0, 8.0, 10.0,10.0, 10.0},
+			wantMin:   8.0,
+			wantMax:   12.0,
+			wantMean:  10.0,
+			wantMedian:  10.0,
+			wantStdDev:  1.0,
+			wantCount: 8,
+			wantSum:   80.0,
 		},
 	}
 
@@ -198,19 +217,25 @@ func TestStatGroupPush(t *testing.T) {
 			sg.push(val)
 		}
 		if got := sg.Min(); got != c.wantMin {
-			t.Errorf("%s: incorrect min: got %f want %f", c.desc, got, c.wantMin)
+			t.Errorf("%s: incorrect Min: got %f want %f", c.desc, got, c.wantMin)
 		}
 		if got := sg.Max(); got != c.wantMax {
-			t.Errorf("%s: incorrect max: got %f want %f", c.desc, got, c.wantMin)
+			t.Errorf("%s: incorrect Max: got %f want %f", c.desc, got, c.wantMin)
 		}
 		if got := sg.Mean(); got != c.wantMean {
-			t.Errorf("%s: incorrect mean: got %f want %f", c.desc, got, c.wantMin)
+			t.Errorf("%s: incorrect Mean: got %f want %f", c.desc, got, c.wantMin)
+		}
+		if got := sg.Median(); got != c.wantMedian {
+			t.Errorf("%s: incorrect Median: got %f want %f", c.desc, got, c.wantMedian)
+		}
+		if got := sg.StdDev(); got != c.wantStdDev {
+			t.Errorf("%s: incorrect StdDev: got %f want %f", c.desc, got, c.wantStdDev)
 		}
 		if got := sg.count; got != c.wantCount {
 			t.Errorf("%s: incorrect count: got %d want %d", c.desc, got, c.wantCount)
 		}
 		if got := sg.sum; got != c.wantSum {
-			t.Errorf("%s: incorrect sum: got %f want %f", c.desc, got, c.wantMin)
+			t.Errorf("%s: incorrect sum: got %f want %f", c.desc, got, c.wantSum)
 		}
 	}
 }

--- a/scripts/full_cycle_minitest_clickhouse.sh
+++ b/scripts/full_cycle_minitest_clickhouse.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
+MAX_RPS=${MAX_RPS:-"0"}
+MAX_QUERIES=${MAX_QUERIES:-"1000"}
+PASSWORD=${PASSWORD:-""}
+
 $GOPATH/bin/tsbs_generate_data --format clickhouse --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/clickhouse_data
 
-$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/clickhouse_query_lastpoint
-$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/clickhouse_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/clickhouse_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/clickhouse_query_lastpoint
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/clickhouse_query_cpu-max-all-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/clickhouse_query_high-cpu-1
 
 $GOPATH/bin/tsbs_load_clickhouse --db-name=benchmark --host=127.0.0.1 --workers=1 --file=/tmp/bulk_data/clickhouse_data
-
-$GOPATH/bin/tsbs_run_queries_clickhouse --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=100 --file=/tmp/bulk_data/clickhouse_query_lastpoint
-$GOPATH/bin/tsbs_run_queries_clickhouse --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=100 --file=/tmp/bulk_data/clickhouse_query_cpu-max-all-1
-$GOPATH/bin/tsbs_run_queries_clickhouse --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=100 --file=/tmp/bulk_data/clickhouse_query_high-cpu-1
+#last point query is broke
+#$GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_lastpoint.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_lastpoint
+$GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_cpu-max-all-1.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_cpu-max-all-1
+$GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_high-cpu-1.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_high-cpu-1
 
 

--- a/scripts/full_cycle_minitest_clickhouse.sh
+++ b/scripts/full_cycle_minitest_clickhouse.sh
@@ -1,19 +1,28 @@
 #!/bin/bash
+# showcases the ftsb 3 phases for clickhouse
+# - 1) data and query generation
+# - 2) data loading/insertion
+# - 3) query execution
 
 MAX_RPS=${MAX_RPS:-"0"}
 MAX_QUERIES=${MAX_QUERIES:-"1000"}
 PASSWORD=${PASSWORD:-""}
 
+mkdir -p /tmp/bulk_data
+
+# generate data
 $GOPATH/bin/tsbs_generate_data --format clickhouse --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/clickhouse_data
 
-$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/clickhouse_query_lastpoint
+# generate queries
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint --file /tmp/bulk_data/clickhouse_query_lastpoint
 $GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/clickhouse_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/clickhouse_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1 --file /tmp/bulk_data/clickhouse_query_high-cpu-1
 
+# insert benchmark
 $GOPATH/bin/tsbs_load_clickhouse --db-name=benchmark --host=127.0.0.1 --workers=1 --file=/tmp/bulk_data/clickhouse_data
+
+# queries benchmark
 #last point query is broke
 #$GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_lastpoint.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_lastpoint
 $GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_cpu-max-all-1.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_cpu-max-all-1
 $GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_high-cpu-1.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_high-cpu-1
-
-

--- a/scripts/full_cycle_minitest_cratedb.sh
+++ b/scripts/full_cycle_minitest_cratedb.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# showcases the ftsb 3 phases for cratedb
+# - 1) data and query generation
+# - 2) data loading/insertion
+# - 3) query execution
 
 # generate data
 mkdir -p /tmp/bulk_data

--- a/scripts/full_cycle_minitest_timescaledb.sh
+++ b/scripts/full_cycle_minitest_timescaledb.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
+MAX_RPS=${MAX_RPS:-"0"}
+MAX_QUERIES=${MAX_QUERIES:-"1000"}
+PASSWORD=${PASSWORD:-""}
+
 $GOPATH/bin/tsbs_generate_data --format timescaledb --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/timescaledb_data
 
-$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/timescaledb_query_lastpoint
-$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/timescaledb_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/timescaledb_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/timescaledb_query_lastpoint
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/timescaledb_query_cpu-max-all-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/timescaledb_query_high-cpu-1
 
-$GOPATH/bin/tsbs_load_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
+$GOPATH/bin/tsbs_load_timescaledb --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
 
-$GOPATH/bin/tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=100 --file=/tmp/bulk_data/timescaledb_query_lastpoint
-$GOPATH/bin/tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=100 --file=/tmp/bulk_data/timescaledb_query_cpu-max-all-1
-$GOPATH/bin/tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=100 --file=/tmp/bulk_data/timescaledb_query_high-cpu-1
+$GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_lastpoint.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_lastpoint
+$GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_cpu-max-all-1.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_cpu-max-all-1
+$GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_high-cpu-1.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_high-cpu-1

--- a/scripts/full_cycle_minitest_timescaledb.sh
+++ b/scripts/full_cycle_minitest_timescaledb.sh
@@ -1,17 +1,27 @@
 #!/bin/bash
+# showcases the ftsb 3 phases for timescaledb
+# - 1) data and query generation
+# - 2) data loading/insertion
+# - 3) query execution
 
 MAX_RPS=${MAX_RPS:-"0"}
 MAX_QUERIES=${MAX_QUERIES:-"1000"}
 PASSWORD=${PASSWORD:-""}
 
+mkdir -p /tmp/bulk_data
+
+# generate queries
 $GOPATH/bin/tsbs_generate_data --format timescaledb --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/timescaledb_data
 
+# generate queries
 $GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/timescaledb_query_lastpoint
 $GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/timescaledb_query_cpu-max-all-1
 $GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/timescaledb_query_high-cpu-1
 
+# insert benchmark
 $GOPATH/bin/tsbs_load_timescaledb --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
 
+# queries benchmark
 $GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_lastpoint.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_lastpoint
 $GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_cpu-max-all-1.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_cpu-max-all-1
 $GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_high-cpu-1.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_high-cpu-1


### PR DESCRIPTION


# Full percentile spectrum analysis
This PR enable full percentile spectrum analysis on query latency so that we can fully understand the performance and stability characteristics of the system we are measuring. 

Right now tsbs is displaying single values targets like the quantile 50, average, min and max. 
Considering that latency does not obey to a normal distribution we should enable ourselfs to do full percentile spectrum analysis. Just looking at a number might be misleading. 

A useful visualization for pointing out the folly of chasing a mean measurement is illustrated below - they have nearly identical simple descriptive statistics, yet have very different distributions and appear very different when graphed.

![image](https://user-images.githubusercontent.com/5832149/67484927-f4734880-f660-11e9-9400-6e0dc09a8a87.png)


Source: https://en.wikipedia.org/wiki/Anscombe%27s_quartet

_______
# Sustainable Throughput:
With that in mind, and to really understand a system behavior we also cant relly solely on doing the full percentile analysis while stressing the system to it's maximum RPS. We need to be able to compare the behavior under different throughputs and/or configurations, to be able to get the best "Sustainable Throughput: The throughput achieved while safely maintaining service levels. 

Adding a further reading slide that will help you understand why this is so important:

https://www.azul.com/files/HowNotToMeasureLatency_LLSummit_NYC_12Nov2013.pdf

![image](https://user-images.githubusercontent.com/5832149/67485495-0ef9f180-f662-11e9-9814-ccfe67f4edc0.png)

_______
# Enabling full percentile spectrum and Sustainable Throughput analysis on tsbs:

The previous features can be applied with the changes added on this PR using the following flags on the `tsbs_run_queries_*` binaries:
-` --hdr-latencies` : enable writing the High Dynamic Range (HDR) Histogram of Response Latencies to the file with the name specified by this. By default no file will be saved. 
-` --max-rps` : enable limiting the rate of queries per second, 0 = no limit. By default no limit is specified and the binaries will behave in the same manner as before. 

## quick example of the beneficts of this addition
Take into consideration that the presented values were obtained to illustrate the added features and not to compared the used systems. This was a local test that should not be used for any other thing rather than to exemplify the new way of assessing stability and performance across the entire latency spectrum when using HDR histograms and rate-limiting.  

### Step 1 - Setup
Running two example docker containers from clickhouse and  timescale in the following manner:
```
docker run -d -p 9000:9000 --ulimit nofile=262144:262144 yandex/clickhouse-server
docker run -d -e POSTGRES_PASSWORD=password -p 5432:5432 timescale/timescaledb
```
### Step 2 - Retrieve sample values
Running two example docker containers from clickhouse and  timescale in the following manner:
```
MAX_QUERIES=1000 MAX_RPS=100 ./scripts/full_cycle_minitest_clickhouse.sh
MAX_QUERIES=1000 MAX_RPS=100 PASSWORD="password" ./scripts/full_cycle_minitest_timescaledb.sh
```
Sample output ( please denote the added `Interval query rate` and `Overall query rate` values
```
(...)
After 100 queries with 1 workers:
Interval query rate: 99.74 queries/sec  Overall query rate: 99.74 queries/sec
ClickHouse CPU over threshold, 1 host(s):
min:     6.03ms, med:     7.36ms, mean:     7.59ms, max:   11.82ms, stddev:     1.12ms, sum:   0.8sec, count: 100
all queries                             :
min:     6.03ms, med:     7.36ms, mean:     7.59ms, max:   11.82ms, stddev:     1.12ms, sum:   0.8sec, count: 100
(...)
```
Final Query benchmark output ( please denote the info regarding in which file the HDR latency file was saved 
```
(...)
Run complete after 1000 queries with 1 workers (Overall query rate 98.42 queries/sec):
ClickHouse CPU over threshold, 1 host(s):
min:     5.78ms, med:     7.52ms, mean:     7.90ms, max:  111.44ms, stddev:     3.54ms, sum:   7.9sec, count: 1000
all queries                             :
min:     5.78ms, med:     7.52ms, mean:     7.90ms, max:  111.44ms, stddev:     3.54ms, sum:   7.9sec, count: 1000
Saving High Dynamic Range (HDR) Histogram of Response Latencies to 100rps_clickhouse_query_high-cpu-1.hdr
wall clock time: 10.178806sec
```
### Step 3 - Use HdrHistogram Plotter
Using the two first output files from the simple full cycle mini tests we can plot the Latency by Percentile Distribution using http://hdrhistogram.github.io/HdrHistogram/plotFiles.html

- [100rps_clickhouse_query_high-cpu-1.txt](https://github.com/filipecosta90/tsbs/files/3767556/100rps_clickhouse_query_high-cpu-1.txt)
- [100rps_timescaledb_query_high-cpu-1.txt](https://github.com/filipecosta90/tsbs/files/3767558/100rps_timescaledb_query_high-cpu-1.txt)
- [100rps_clickhouse_query_cpu-max-all-1.txt](https://github.com/filipecosta90/tsbs/files/3767555/100rps_clickhouse_query_cpu-max-all-1.txt)
- [100rps_timescaledb_query_cpu-max-all-1.txt](https://github.com/filipecosta90/tsbs/files/3767557/100rps_timescaledb_query_cpu-max-all-1.txt)

Which will enable us to get the "full picture" of latency distribution. If we only analyzed the P99 latency we would be tempted to state that clickhouse had better values. However, if you look and the second image you see that on overall  the stability of timescale is greater. Take into consideration that obtained values are only for illustration purposes and to justify that single values targets can lead us to the wrong conclusions. 

![Screen Shot 2019-10-24 at 1 46 58 PM](https://user-images.githubusercontent.com/5832149/67487067-29819a00-f665-11e9-8300-1a0db871bd23.png)
![Screen Shot 2019-10-24 at 1 46 44 PM](https://user-images.githubusercontent.com/5832149/67487098-3c946a00-f665-11e9-9b7c-470e6b8c4e07.png)


# credits 
HdrHistogram was originally authored by Gil Tene (@giltene) and placed in the public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/, with ports by Mike Barker (@mikeb01) (C), Matt Warren (@mattwarren) (C#), Darach Ennis (@darach) (Erlang), Alec Hothan (@ahothan) (Python), Coda Hale (@codahale) (Go) (which i needed to revamp), Jon Gjengset (@jonhoo) (Rust), and Alexandre Victoor (@alexvictoor) (JavaScript)

