### PR TITLE
Add native PG to IoT benchmark

### DIFF
--- a/cmd/tsbs_generate_queries/databases/timescaledb/common.go
+++ b/cmd/tsbs_generate_queries/databases/timescaledb/common.go
@@ -1,6 +1,7 @@
 package timescaledb
 
 import (
+        "fmt"
 	"time"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
@@ -9,13 +10,28 @@ import (
 	"github.com/timescale/tsbs/query"
 )
 
-const goTimeFmt = "2006-01-02 15:04:05.999999 -0700"
+const (
+	goTimeFmt = "2006-01-02 15:04:05.999999 -0700"
+
+	oneMinute = 60
+	oneHour   = oneMinute * 60
+
+	timeBucketFmt    = "time_bucket('%d seconds', %s)"
+	nonTimeBucketFmt = "to_timestamp(((extract(epoch from %s)::int)/%d)*%d)"
+)
 
 // BaseGenerator contains settings specific for TimescaleDB
 type BaseGenerator struct {
 	UseJSON       bool
 	UseTags       bool
 	UseTimeBucket bool
+}
+
+func (g *BaseGenerator) getTimeBucket(seconds int, column string) string {
+	if g.UseTimeBucket {
+		return fmt.Sprintf(timeBucketFmt, seconds, column)
+	}
+	return fmt.Sprintf(nonTimeBucketFmt, column, seconds, seconds)
 }
 
 // GenerateEmptyQuery returns an empty query.TimescaleDB.

--- a/cmd/tsbs_generate_queries/databases/timescaledb/common.go
+++ b/cmd/tsbs_generate_queries/databases/timescaledb/common.go
@@ -1,7 +1,7 @@
 package timescaledb
 
 import (
-        "fmt"
+	"fmt"
 	"time"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"

--- a/cmd/tsbs_generate_queries/databases/timescaledb/iot.go
+++ b/cmd/tsbs_generate_queries/databases/timescaledb/iot.go
@@ -206,7 +206,7 @@ func (i *IoT) TrucksWithLongDrivingSessions(qi query.Query) {
 		HAVING count(r.ten_minutes) > %d`,
 		i.withAlias(name),
 		i.withAlias(driver),
-		i.getTimeBucket(10 * oneMinute, "time"),
+		i.getTimeBucket(10*oneMinute, "time"),
 		interval.Start().Format(goTimeFmt),
 		interval.End().Format(goTimeFmt),
 		i.columnSelect(name),
@@ -241,7 +241,7 @@ func (i *IoT) TrucksWithLongDailySessions(qi query.Query) {
 		HAVING count(r.ten_minutes) > %d`,
 		i.withAlias(name),
 		i.withAlias(driver),
-                i.getTimeBucket(10 * oneMinute, "time"),
+		i.getTimeBucket(10*oneMinute, "time"),
 		interval.Start().Format(goTimeFmt),
 		interval.End().Format(goTimeFmt),
 		i.columnSelect(name),
@@ -300,8 +300,8 @@ func (i *IoT) AvgDailyDrivingDuration(qi query.Query) {
 		FROM daily_total_session d
 		INNER JOIN tags t ON t.id = d.tags_id
 		GROUP BY fleet, name, driver`,
-                i.getTimeBucket(10 * oneMinute, "TIME"),
-                i.getTimeBucket(24 * oneHour, "ten_minutes"),
+		i.getTimeBucket(10*oneMinute, "TIME"),
+		i.getTimeBucket(24*oneHour, "ten_minutes"),
 		i.withAlias(fleet),
 		i.withAlias(name),
 		i.withAlias(driver))
@@ -338,9 +338,9 @@ func (i *IoT) AvgDailyDrivingSession(qi query.Query) {
 		AND d.driving = true
 		GROUP BY name, day
 		ORDER BY name, day`,
-                i.getTimeBucket(10 * oneMinute, "TIME"),
+		i.getTimeBucket(10*oneMinute, "TIME"),
 		i.withAlias(name),
-                i.getTimeBucket(24 * oneHour, "start"),
+		i.getTimeBucket(24*oneHour, "start"),
 		i.columnSelect(name))
 
 	humanLabel := "TimescaleDB average driver driving session without stopping per day"
@@ -391,8 +391,8 @@ func (i *IoT) DailyTruckActivity(qi query.Query) {
 		ORDER BY y.day`,
 		i.withAlias(fleet),
 		i.withAlias(model),
-                i.getTimeBucket(24 * oneHour, "time"),
-                i.getTimeBucket(10 * oneMinute, "time"),
+		i.getTimeBucket(24*oneHour, "time"),
+		i.getTimeBucket(10*oneMinute, "time"),
 		i.columnSelect(name))
 
 	humanLabel := "TimescaleDB daily truck activity per fleet per model"
@@ -423,7 +423,7 @@ func (i *IoT) TruckBreakdownFrequency(qi query.Query) {
 		WHERE t.%s IS NOT NULL
 		AND broken_down = false AND next_broken_down = true
 		GROUP BY model`,
-                i.getTimeBucket(10 * oneMinute, "time"),
+		i.getTimeBucket(10*oneMinute, "time"),
 		i.withAlias(model),
 		i.columnSelect(name))
 

--- a/cmd/tsbs_generate_queries/databases/timescaledb/iot.go
+++ b/cmd/tsbs_generate_queries/databases/timescaledb/iot.go
@@ -194,7 +194,7 @@ func (i *IoT) TrucksWithLongDrivingSessions(qi query.Query) {
 	sql := fmt.Sprintf(`SELECT t.%s, t.%s
 		FROM tags t 
 		INNER JOIN LATERAL 
-			(SELECT  time_bucket('10 minutes', time) AS ten_minutes, tags_id  
+			(SELECT %s AS ten_minutes, tags_id  
 			FROM readings 
 			WHERE time >= '%s' AND time < '%s'
 			GROUP BY ten_minutes, tags_id  
@@ -206,6 +206,7 @@ func (i *IoT) TrucksWithLongDrivingSessions(qi query.Query) {
 		HAVING count(r.ten_minutes) > %d`,
 		i.withAlias(name),
 		i.withAlias(driver),
+		i.getTimeBucket(10 * oneMinute, "time"),
 		interval.Start().Format(goTimeFmt),
 		interval.End().Format(goTimeFmt),
 		i.columnSelect(name),
@@ -228,7 +229,7 @@ func (i *IoT) TrucksWithLongDailySessions(qi query.Query) {
 	sql := fmt.Sprintf(`SELECT t.%s, t.%s
 		FROM tags t 
 		INNER JOIN LATERAL 
-			(SELECT  time_bucket('10 minutes', time) AS ten_minutes, tags_id  
+			(SELECT %s AS ten_minutes, tags_id  
 			FROM readings 
 			WHERE time >= '%s' AND time < '%s'
 			GROUP BY ten_minutes, tags_id  
@@ -240,6 +241,7 @@ func (i *IoT) TrucksWithLongDailySessions(qi query.Query) {
 		HAVING count(r.ten_minutes) > %d`,
 		i.withAlias(name),
 		i.withAlias(driver),
+                i.getTimeBucket(10 * oneMinute, "time"),
 		interval.Start().Format(goTimeFmt),
 		interval.End().Format(goTimeFmt),
 		i.columnSelect(name),
@@ -284,13 +286,13 @@ func (i *IoT) AvgDailyDrivingDuration(qi query.Query) {
 
 	sql := fmt.Sprintf(`WITH ten_minute_driving_sessions
 		AS (
-			SELECT time_bucket('10 minutes', TIME) AS ten_minutes, tags_id
+			SELECT %s AS ten_minutes, tags_id
 			FROM readings r
 			GROUP BY tags_id, ten_minutes
 			HAVING avg(velocity) > 1
 			), daily_total_session
 		AS (
-			SELECT time_bucket('24 hours', ten_minutes) AS day, tags_id, count(*) / 6 AS hours
+			SELECT %s AS day, tags_id, count(*) / 6 AS hours
 			FROM ten_minute_driving_sessions
 			GROUP BY day, tags_id
 			)
@@ -298,6 +300,8 @@ func (i *IoT) AvgDailyDrivingDuration(qi query.Query) {
 		FROM daily_total_session d
 		INNER JOIN tags t ON t.id = d.tags_id
 		GROUP BY fleet, name, driver`,
+                i.getTimeBucket(10 * oneMinute, "TIME"),
+                i.getTimeBucket(24 * oneHour, "ten_minutes"),
 		i.withAlias(fleet),
 		i.withAlias(name),
 		i.withAlias(driver))
@@ -314,7 +318,7 @@ func (i *IoT) AvgDailyDrivingSession(qi query.Query) {
 
 	sql := fmt.Sprintf(`WITH driver_status
 		AS (
-			SELECT tags_id, time_bucket('10 mins', TIME) AS ten_minutes, avg(velocity) > 5 AS driving
+			SELECT tags_id, %s AS ten_minutes, avg(velocity) > 5 AS driving
 			FROM readings
 			GROUP BY tags_id, ten_minutes
 			ORDER BY tags_id, ten_minutes
@@ -327,14 +331,16 @@ func (i *IoT) AvgDailyDrivingSession(qi query.Query) {
 				) x
 			WHERE x.driving <> x.prev_driving
 			)
-		SELECT t.%s, time_bucket('24 hours', start) AS day, avg(age(stop, start)) AS duration
+		SELECT t.%s, %s AS day, avg(age(stop, start)) AS duration
 		FROM tags t
 		INNER JOIN driver_status_change d ON t.id = d.tags_id
 		WHERE t.%s IS NOT NULL
 		AND d.driving = true
 		GROUP BY name, day
 		ORDER BY name, day`,
+                i.getTimeBucket(10 * oneMinute, "TIME"),
 		i.withAlias(name),
+                i.getTimeBucket(24 * oneHour, "start"),
 		i.columnSelect(name))
 
 	humanLabel := "TimescaleDB average driver driving session without stopping per day"
@@ -375,7 +381,7 @@ func (i *IoT) DailyTruckActivity(qi query.Query) {
 	sql := fmt.Sprintf(`SELECT t.%s, t.%s, y.day, sum(y.ten_mins_per_day) / 144 AS daily_activity
 		FROM tags t
 		INNER JOIN (
-			SELECT time_bucket('24 hours', TIME) AS day, time_bucket('10 minutes', TIME) AS ten_minutes, tags_id, count(*) AS ten_mins_per_day
+			SELECT %s AS day, %s AS ten_minutes, tags_id, count(*) AS ten_mins_per_day
 			FROM diagnostics
 			GROUP BY day, ten_minutes, tags_id
 			HAVING avg(STATUS) < 1
@@ -385,6 +391,8 @@ func (i *IoT) DailyTruckActivity(qi query.Query) {
 		ORDER BY y.day`,
 		i.withAlias(fleet),
 		i.withAlias(model),
+                i.getTimeBucket(24 * oneHour, "time"),
+                i.getTimeBucket(10 * oneMinute, "time"),
 		i.columnSelect(name))
 
 	humanLabel := "TimescaleDB daily truck activity per fleet per model"
@@ -399,7 +407,7 @@ func (i *IoT) TruckBreakdownFrequency(qi query.Query) {
 
 	sql := fmt.Sprintf(`WITH breakdown_per_truck_per_ten_minutes
 		AS (
-			SELECT time_bucket('10 minutes', TIME) AS ten_minutes, tags_id, count(STATUS = 0) / count(*) >= 0.5 AS broken_down
+			SELECT %s AS ten_minutes, tags_id, count(STATUS = 0) / count(*) >= 0.5 AS broken_down
 			FROM diagnostics
 			GROUP BY ten_minutes, tags_id
 			), breakdowns_per_truck
@@ -415,6 +423,7 @@ func (i *IoT) TruckBreakdownFrequency(qi query.Query) {
 		WHERE t.%s IS NOT NULL
 		AND broken_down = false AND next_broken_down = true
 		GROUP BY model`,
+                i.getTimeBucket(10 * oneMinute, "time"),
 		i.withAlias(model),
 		i.columnSelect(name))
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/SiriDB/go-siridb-connector v0.0.0-20190110105621-86b34c44c921
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+	github.com/filipecosta90/hdrhistogram v0.0.0-20191025144016-6360d1757d33
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gocql/gocql v0.0.0-20190810123941-df4b9cc33030
@@ -25,5 +26,6 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/transceptor-technology/go-qpack v0.0.0-20190116123619-49a14b216a45
 	github.com/valyala/fasthttp v1.4.0
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/appengine v1.6.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/filipecosta90/hdrhistogram v0.0.0-20191025144016-6360d1757d33 h1:KURw4yhtighHMtV5MeHqI1GYvC8MAfAatn2K5J5INvI=
+github.com/filipecosta90/hdrhistogram v0.0.0-20191025144016-6360d1757d33/go.mod h1:Ws7v8qrWA96aL9o9Hl6X334iRA+l61XXODY/HY6JdvU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -272,6 +274,7 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Like with DevOps, I added the ability to use `date_trunc` instead of `time_bucket` for the IoT case.

NB: not sure about `go.sum` and `go.mod` files...