### PR TITLE
[add] added Makefile and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# ignore .git and .cache folders
+.git
+.editorconfig
+.gitignore
+.dockerignore
+.travis.yml
+coverage.txt
+AUTHORS.md
+CONTRIBUTING.md
+LICENSE
+NOTICE
+README.md
+
+*.out
+*.log
+.DS_Store
+.idea
+.vscode
+**/bin
+**/docs
+**/scripts
+
+# High Dynamic Range (HDR) Histogram files
+*.hdr

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOINSTALL=$(GOCMD) install
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+
+# DOCKER
+DOCKER_APP_NAME=tsbs
+DOCKER_ORG=timescale
+DOCKER_REPO:=${DOCKER_ORG}/${DOCKER_APP_NAME}
+DOCKER_IMG:="$(DOCKER_REPO):$(DOCKER_TAG)"
+DOCKER_LATEST:="${DOCKER_REPO}:latest"
+
+.PHONY: all generators loaders runners
+all: generators loaders runners
+
+generators: tsbs_generate_data tsbs_generate_queries
+
+loaders: tsbs_load_cassandra tsbs_load_clickhouse tsbs_load_influx tsbs_load_mongo tsbs_load_siridb tsbs_load_timescaledb
+
+runners: tsbs_run_queries_cassandra tsbs_run_queries_clickhouse tsbs_run_queries_influx tsbs_run_queries_mongo tsbs_run_queries_siridb tsbs_run_queries_timescaledb
+
+test:
+	GO111MODULE=on $(GOTEST) -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+tsbs_%: $(wildcard ./cmd/$@/*.go)
+	$(GOGET) ./cmd/$@
+	$(GOBUILD) -o bin/$@ ./cmd/$@
+	$(GOINSTALL) ./cmd/$@
+
+# DOCKER TASKS
+# Build the container
+docker-build:
+	docker build -t $(DOCKER_APP_NAME):latest -f  docker/Dockerfile .
+
+# Build the container without caching
+docker-build-nc:
+	docker build --no-cache -t $(DOCKER_APP_NAME):latest -f docker/Dockerfile .
+
+# Make a release by building and publishing the `{version}` ans `latest` tagged containers to ECR
+docker-release: docker-build-nc docker-publish
+
+# Docker publish
+docker-publish: docker-publish-latest
+
+## login to DockerHub with credentials found in env
+docker-repo-login:
+	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+
+## Publish the `latest` tagged container to ECR
+docker-publish-latest: docker-tag-latest
+	@echo 'publish latest to $(DOCKER_REPO)'
+	docker push $(DOCKER_LATEST)
+
+# Docker tagging
+docker-tag: docker-tag-latest
+
+## Generate container `{version}` tag
+docker-tag-latest:
+	@echo 'create tag latest'
+	docker tag $(DOCKER_APP_NAME) $(DOCKER_LATEST)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.13.5-alpine AS builder
+
+# Copy the code from the host and compile it
+WORKDIR $GOPATH/src/github.com/timescale/tsbs
+COPY . ./
+RUN apk add --no-cache git make bash
+RUN make all
+
+FROM golang:1.13.5-alpine
+# install bash shell
+RUN apk add --update bash && rm -rf /var/cache/apk/*
+
+ENV PATH ./:$PATH
+COPY --from=builder $GOPATH/src/github.com/timescale/tsbs/bin/tsbs_* ./
+COPY ./docker/docker_entrypoint.sh ./
+RUN chmod 751 docker_entrypoint.sh
+ENTRYPOINT ["./docker_entrypoint.sh"]

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Ensure runner is available
+EXE_FILE_NAME=$(which $1)
+if [[ -z "$EXE_FILE_NAME" ]]; then
+  echo "$1 not available. It is not specified explicitly and not found in \$PATH"
+  exit 1
+else
+  "$@"
+  exit 0
+fi


### PR DESCRIPTION
# overall PR description 

adds a Makefile and Dockerfile which enables to build all binaries ( or by a group ) and to create an overall tsbs docker image that allows us to benchmark all databases.

to build the binaries simply:
```
make 
```
to build the docker image simply:
```
make docker-build-nc 
```

## Sample docker run command:
```
$ docker run -it --rm tsbs:latest tsbs_load_influx -h
Usage of tsbs_load_influx:
      --backoff duration            Time to sleep between requests when server indicates backpressure is needed. (default 1s)
      --batch-size uint             Number of items to batch together in a single insert (default 10000)
      --consistency string          Write consistency. Must be one of: any, one, quorum, all. (default "all")
      --db-name string              Name of database (default "benchmark")
      --do-abort-on-exist           Whether to abort if a database with the given name already exists.
      --do-create-db                Whether to create the database. Disable on all but one client if running on a multi client setup. (default true)
      --do-load                     Whether to write data. Set this flag to false to check input read speed. (default true)
      --file string                 File name to read data from
      --gzip                        Whether to gzip encode requests (default true). (default true)
      --limit uint                  Number of items to insert (0 = all of them).
      --replication-factor int      Cluster replication factor (only applies to clustered databases). (default 1)
      --reporting-period duration   Period to report write stats (default 10s)
      --seed int                    PRNG seed (default: 0, which uses the current timestamp)
      --urls string                 InfluxDB URLs, comma-separated. Will be used in a round-robin fashion. (default "http://localhost:8086")
      --workers uint                Number of parallel clients inserting (default 1)
pflag: help requested
```

## Sample output of wrong input from user ( no binary with that name ):
```
$ docker run -it --rm tsbs:latest WRONGBIN
WRONGBIN not available. It is not specified explicitly and not found in $PATH
```