### PR TITLE
 [fix] fixed cpu-max-all-* wrong influxql group by time clause

### DIFF
--- a/cmd/tsbs_generate_queries/databases/influx/common.go
+++ b/cmd/tsbs_generate_queries/databases/influx/common.go
@@ -26,6 +26,7 @@ func (g *BaseGenerator) fillInQuery(qi query.Query, humanLabel, humanDesc, influ
 	v.Set("q", influxql)
 	q := qi.(*query.HTTP)
 	q.HumanLabel = []byte(humanLabel)
+	q.RawQuery = []byte(influxql)
 	q.HumanDescription = []byte(humanDesc)
 	q.Method = []byte("POST")
 	q.Path = []byte(fmt.Sprintf("/query?%s", v.Encode()))

--- a/cmd/tsbs_generate_queries/databases/influx/devops.go
+++ b/cmd/tsbs_generate_queries/databases/influx/devops.go
@@ -111,7 +111,7 @@ func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
 
 	humanLabel := devops.GetMaxAllLabel("Influx", nHosts)
 	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
-	influxql := fmt.Sprintf("SELECT %s from cpu where %s and time >= '%s' and time < '%s' group by time(1m)", strings.Join(selectClauses, ","), whereHosts, interval.StartString(), interval.EndString())
+	influxql := fmt.Sprintf("SELECT %s from cpu where %s and time >= '%s' and time < '%s' group by time(1h)", strings.Join(selectClauses, ","), whereHosts, interval.StartString(), interval.EndString())
 	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
 }
 

--- a/cmd/tsbs_generate_queries/databases/influx/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/influx/devops_test.go
@@ -251,7 +251,7 @@ func TestMaxAllCPU(t *testing.T) {
 				"from cpu " +
 				"where (hostname = 'host_3') and " +
 				"time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T08:54:10Z' " +
-				"group by time(1m)",
+				"group by time(1h)",
 		},
 		{
 			desc:               "5 hosts",
@@ -263,7 +263,7 @@ func TestMaxAllCPU(t *testing.T) {
 				"from cpu " +
 				"where (hostname = 'host_9' or hostname = 'host_5' or hostname = 'host_1' or hostname = 'host_7' or hostname = 'host_2') " +
 				"and time >= '1970-01-01T00:37:12Z' and time < '1970-01-01T08:37:12Z' " +
-				"group by time(1m)",
+				"group by time(1h)",
 		},
 	}
 

--- a/cmd/tsbs_run_queries_influx/http_client.go
+++ b/cmd/tsbs_run_queries_influx/http_client.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -104,17 +103,18 @@ func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, 
 			// Assumes the response is JSON! This holds for Influx
 			// and Elastic.
 
-			var pretty bytes.Buffer
 			prefix := fmt.Sprintf("ID %d: ", q.GetID())
-			err = json.Indent(&pretty, body, prefix, "  ")
+			var v interface{}
+			var line []byte
+			full := make(map[string]interface{})
+			full["influxql"] = string(q.RawQuery)
+			json.Unmarshal(body, &v)
+			full["response"] = v
+			line, err = json.MarshalIndent(full, prefix, "  ")
 			if err != nil {
 				return
 			}
-
-			_, err = fmt.Fprintf(os.Stderr, "%s%s\n", prefix, pretty.Bytes())
-			if err != nil {
-				return
-			}
+			fmt.Println(string(line) + "\n")
 		}
 	}
 

--- a/query/http.go
+++ b/query/http.go
@@ -13,6 +13,7 @@ type HTTP struct {
 	Method           []byte
 	Path             []byte
 	Body             []byte
+	RawQuery         []byte
 	StartTimestamp   int64
 	EndTimestamp     int64
 	id               uint64
@@ -27,6 +28,7 @@ var HTTPPool = sync.Pool{
 			Method:           []byte{},
 			Path:             []byte{},
 			Body:             []byte{},
+			RawQuery:         []byte{},
 			StartTimestamp:   0,
 			EndTimestamp:     0,
 		}


### PR DESCRIPTION
# overall description 
solves #109 
[fix] fixed cpu-max-all-* for influx.
[add] added influxql to --print-responses option within query runner

If you guys compare timescale's and influx's results for cpu-max-all-1 and cpu-max-all-8 queries, you will notice that there is a wrong group by time clause on influx ( group by time(1m) should be group by time(1h). The changes in this PR fix the issue and improvement the resultset output for influx ( so that we can easily check this type of error.

# current master cpu-max-all-1 ( notice group by minute )
```
ID 0: {
ID 0:   "results": [
ID 0:     {
ID 0:       "statement_id": 0,
ID 0:       "series": [
ID 0:         {
ID 0:           "name": "cpu",
ID 0:           "columns": [
ID 0:             "time",
ID 0:             "max",
ID 0:             "max_1",
ID 0:             "max_2",
ID 0:             "max_3",
ID 0:             "max_4",
ID 0:             "max_5",
ID 0:             "max_6",
ID 0:             "max_7",
ID 0:             "max_8",
ID 0:             "max_9"
ID 0:           ],
ID 0:           "values": [
ID 0:             [
ID 0:               "2016-01-01T02:16:00Z",
ID 0:               36,
ID 0:               9,
ID 0:               49,
ID 0:               13,
ID 0:               32,
ID 0:               3,
ID 0:               9,
ID 0:               29,
ID 0:               23,
ID 0:               52
ID 0:             ],
ID 0:             [
ID 0:               "2016-01-01T02:17:00Z",
ID 0:               37,
ID 0:               10,
ID 0:               47,
ID 0:               11,
ID 0:               32,
ID 0:               7,
ID 0:               10,
ID 0:               28,
ID 0:               25,
ID 0:               52
ID 0:             ],
ID 0:             [
ID 0:               "2016-01-01T02:18:00Z",
ID 0:               39,
ID 0:               10,
ID 0:               44,
ID 0:               13,
ID 0:               28,
ID 0:               9,
ID 0:               7,
ID 0:               30,
ID 0:               28,
ID 0:               51
ID 0:             ],
(...)
```

# after fix  cpu-max-all-1 ( notice group by hour )
```
{
ID 0:   "influxql": "SELECT max(usage_user),max(usage_system),max(usage_idle),max(usage_nice),max(usage_iowait),max(usage_irq),max(usage_softirq),max(usage_steal),max(usage_guest),max(usage_guest_nice) from cpu where (hostname = 'host_9') and time \u003e= '2016-01-01T02:16:22Z' and time \u003c '2016-01-01T10:16:22Z' group by time(1h)",
ID 0:   "response": {
ID 0:     "results": [
ID 0:       {
ID 0:         "series": [
ID 0:           {
ID 0:             "columns": [
ID 0:               "time",
ID 0:               "max",
ID 0:               "max_1",
ID 0:               "max_2",
ID 0:               "max_3",
ID 0:               "max_4",
ID 0:               "max_5",
ID 0:               "max_6",
ID 0:               "max_7",
ID 0:               "max_8",
ID 0:               "max_9"
ID 0:             ],
ID 0:             "name": "cpu",
ID 0:             "values": [
ID 0:               [
ID 0:                 "2016-01-01T02:00:00Z",
ID 0:                 48,
ID 0:                 11,
ID 0:                 55,
ID 0:                 17,
ID 0:                 46,
ID 0:                 25,
ID 0:                 33,
ID 0:                 44,
ID 0:                 38,
ID 0:                 52
ID 0:               ],
ID 0:               [
ID 0:                 "2016-01-01T03:00:00Z",
ID 0:                 27,
ID 0:                 9,
ID 0:                 84,
ID 0:                 27,
ID 0:                 52,
ID 0:                 35,
ID 0:                 33,
ID 0:                 85,
ID 0:                 40,
ID 0:                 59
ID 0:               ],
(...)
```