### PR TITLE
Update CI to only test on Go 1.13 and 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,16 @@ language: go
 jobs:
   include:
     - stage: test
-      name: "Go without modules (1.10)"
-      go:
-        - 1.10.x
-      go_import_path: github.com/timescale/tsbs
-      before_install:
-        - go get -t -v ./...
-      script:
-        - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-    - stage: test
-      name: "Go with modules (1.11)"
-      go:
-        - 1.11.x
-      install: skip
-      script:
-        - GO111MODULE=on go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-    - stage: test
-      name: "Go with modules (1.12)"
-      go:
-        - 1.12.x
-      install: skip
-      script:
-        - GO111MODULE=on go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-    - stage: test
-      name: "Go with modules (1.13)"
+      name: "Go 1.13"
       go:
         - 1.13.x
+      install: skip
+      script:
+        - GO111MODULE=on go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+    - stage: test
+      name: "Go 1.14"
+      go:
+        - 1.14.x
       install: skip
       script:
         - GO111MODULE=on go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/SiriDB/go-siridb-connector v0.0.0-20190110105621-86b34c44c921
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+	github.com/filipecosta90/hdrhistogram v0.0.0-20191025144016-6360d1757d33
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gocql/gocql v0.0.0-20190810123941-df4b9cc33030
 	github.com/google/flatbuffers v1.11.0
 	github.com/google/go-cmp v0.3.1
-	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgconn v1.1.0
 	github.com/jackc/pgx/v4 v4.1.1
 	github.com/jmoiron/sqlx v1.2.0
@@ -25,5 +25,6 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/transceptor-technology/go-qpack v0.0.0-20190116123619-49a14b216a45
 	github.com/valyala/fasthttp v1.4.0
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/appengine v1.6.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/filipecosta90/hdrhistogram v0.0.0-20191025144016-6360d1757d33 h1:KURw4yhtighHMtV5MeHqI1GYvC8MAfAatn2K5J5INvI=
+github.com/filipecosta90/hdrhistogram v0.0.0-20191025144016-6360d1757d33/go.mod h1:Ws7v8qrWA96aL9o9Hl6X334iRA+l61XXODY/HY6JdvU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -82,8 +84,6 @@ github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZb
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0 h1:DUwgMQuuPnS0rhMXenUtZpqZqrR/30NWY+qQvTpSvEs=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
-github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 h1:vr3AYkKovP8uR8AvSGGUK1IDqRa5lAAvEkZG1LKaCRc=
-github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgconn v0.0.0-20190420214824-7e0022ef6ba3/go.mod h1:jkELnwuX+w9qN5YIfX0fl88Ehu4XC3keFuOJJk9pcnA=
 github.com/jackc/pgconn v0.0.0-20190824142844-760dd75542eb/go.mod h1:lLjNuW/+OfW9/pnVKPazfWOgNfH2aPem8YQ7ilXGvJE=
 github.com/jackc/pgconn v0.0.0-20190831204454-2fabfa3c18b7/go.mod h1:ZJKsE/KZfsUgOEh9hBm+xYTstcNHg7UPMVJqRfQxq4s=
@@ -272,6 +272,7 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
With the release of Go 1.14, versions before 1.13 are no longer
supported by the Go team. Therefore we can remove them from the
CI testing.