### PR TITLE
Fix HTTP client keepalive for influx

### DIFF
--- a/cmd/tsbs_run_queries_influx/http_client.go
+++ b/cmd/tsbs_run_queries_influx/http_client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/timescale/tsbs/query"
@@ -17,7 +18,7 @@ var bytesSlash = []byte("/") // heap optimization
 // HTTPClient is a reusable HTTP Client.
 type HTTPClient struct {
 	//client     fasthttp.Client
-	client     http.Client
+	client     *http.Client
 	Host       []byte
 	HostString string
 	uri        []byte
@@ -31,10 +32,23 @@ type HTTPClientDoOptions struct {
 	database             string
 }
 
+var httpClientOnce = sync.Once{}
+var httpClient *http.Client
+
+func getHttpClient() *http.Client {
+	httpClientOnce.Do(func() {
+		tr := &http.Transport{
+			MaxIdleConnsPerHost: 1024,
+		}
+		httpClient = &http.Client{Transport: tr}
+	})
+	return httpClient
+}
+
 // NewHTTPClient creates a new HTTPClient.
 func NewHTTPClient(host string) *HTTPClient {
 	return &HTTPClient{
-		client:     http.Client{},
+		client:     getHttpClient(),
 		Host:       []byte(host),
 		HostString: host,
 		uri:        []byte{}, // heap optimization


### PR DESCRIPTION
Previously, every worker thread created its own HTTP Client instance
which shared the underlying go default HTTP transport. The default
transport limits its max idle connections per host to 2.

This meant that, when running with --workers > 2, there would be moments
in time with more thn two idle connections and connections would be
dropped and need to be reconnected. Without this change, a run of many
thousand queries with 8 workers would reconnect ~1000 times. With the
change, it only connects once per worker.