### PR TITLE
Bugfix for tsbs_run_queries_cassandra, missing config struct

### DIFF
--- a/cmd/tsbs_run_queries_cassandra/main.go
+++ b/cmd/tsbs_run_queries_cassandra/main.go
@@ -77,6 +77,10 @@ func init() {
 		panic(fmt.Errorf("fatal error config file: %s", err))
 	}
 
+	if err := viper.Unmarshal(&config); err != nil {
+		panic(fmt.Errorf("unable to decode config: %s", err))
+	}
+
 	daemonURL = viper.GetString("host")
 	aggrPlanLabel = viper.GetString("aggregation-plan")
 	requestTimeout = viper.GetDuration("read-timeout")


### PR DESCRIPTION
Added initialization of config struct to set default parameters and enable the setting of the respective parameters via command line args for tsbs_run_queries_cassandra.

See also the opened issue #124: https://github.com/timescale/tsbs/issues/124