### PR TITLE
Added Makefile to simplify build and test process; Ensure proper go fmt is maintained

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+# Go parameters
+GOCMD=GO111MODULE=on go
+GOBUILD=$(GOCMD) build
+GOINSTALL=$(GOCMD) install
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+GOFMT=$(GOCMD) fmt
+
+.PHONY: all generators loaders runners lint fmt checkfmt
+
+all: generators loaders runners
+
+generators: tsbs_generate_data \
+			tsbs_generate_queries
+
+loaders: tsbs_load \
+		 tsbs_load_akumuli \
+		 tsbs_load_cassandra \
+		 tsbs_load_clickhouse \
+		 tsbs_load_cratedb \
+		 tsbs_load_influx \
+ 		 tsbs_load_mongo \
+ 		 tsbs_load_prometheus \
+ 		 tsbs_load_siridb \
+ 		 tsbs_load_timescaledb \
+ 		 tsbs_load_victoriametrics
+
+runners: tsbs_run_queries_akumuli \
+		 tsbs_run_queries_cassandra \
+		 tsbs_run_queries_clickhouse \
+		 tsbs_run_queries_cratedb \
+		 tsbs_run_queries_influx \
+		 tsbs_run_queries_mongo \
+		 tsbs_run_queries_siridb \
+		 tsbs_run_queries_timescaledb \
+		 tsbs_run_queries_timestream \
+		 tsbs_run_queries_victoriametrics
+
+test:
+	$(GOTEST) -v ./...
+
+coverage:
+	$(GOTEST) -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+tsbs_%: $(wildcard ./cmd/$@/*.go)
+	$(GOGET) ./cmd/$@
+	$(GOBUILD) -o bin/$@ ./cmd/$@
+	$(GOINSTALL) ./cmd/$@
+
+checkfmt:
+	@echo 'Checking gofmt';\
+ 	bash -c "diff -u <(echo -n) <(gofmt -d .)";\
+	EXIT_CODE=$$?;\
+	if [ "$$EXIT_CODE"  -ne 0 ]; then \
+		echo '$@: Go files must be formatted with gofmt'; \
+	fi && \
+	exit $$EXIT_CODE
+
+lint:
+	$(GOGET) github.com/golangci/golangci-lint/cmd/golangci-lint
+	golangci-lint run
+
+fmt:
+	$(GOFMT) ./...

--- a/README.md
+++ b/README.md
@@ -102,25 +102,12 @@ with identical data and queried using identical queries.
 
 TSBS is a collection of Go programs (with some auxiliary bash and Python
 scripts). The easiest way to get and install the Go programs is to use
-`go get` and then `go install`:
+`go get` and then `make all` to instal all binaries:
 ```bash
 # Fetch TSBS and its dependencies
 $ go get github.com/timescale/tsbs
-$ cd $GOPATH/src/github.com/timescale/tsbs/cmd
-$ go get ./...
-
-# Install desired binaries. At a minimum this includes tsbs_generate_data,
-# tsbs_generate_queries, one tsbs_load_* binary, and one tsbs_run_queries_*
-# binary:
-$ cd $GOPATH/src/github.com/timescale/tsbs/cmd
-$ cd tsbs_generate_data && go install
-$ cd ../tsbs_generate_queries && go install
-$ cd ../tsbs_load_timescaledb && go install
-$ cd ../tsbs_run_queries_timescaledb && go install
-
-# Optionally, install all binaries:
-$ cd $GOPATH/src/github.com/timescale/tsbs/cmd
-$ go install ./...
+$ cd $GOPATH/src/github.com/timescale/tsbs
+$ make
 ```
 
 ## How to use TSBS

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ with identical data and queried using identical queries.
 
 TSBS is a collection of Go programs (with some auxiliary bash and Python
 scripts). The easiest way to get and install the Go programs is to use
-`go get` and then `make all` to instal all binaries:
+`go get` and then `make all` to install all binaries:
 ```bash
 # Fetch TSBS and its dependencies
 $ go get github.com/timescale/tsbs

--- a/pkg/query/stats.go
+++ b/pkg/query/stats.go
@@ -2,10 +2,11 @@ package query
 
 import (
 	"fmt"
-	"github.com/HdrHistogram/hdrhistogram-go"
 	"io"
 	"sort"
 	"sync"
+
+	"github.com/HdrHistogram/hdrhistogram-go"
 )
 
 var (

--- a/pkg/query/stats.go
+++ b/pkg/query/stats.go
@@ -2,10 +2,10 @@ package query
 
 import (
 	"fmt"
+	"github.com/HdrHistogram/hdrhistogram-go"
 	"io"
 	"sort"
 	"sync"
-	"github.com/HdrHistogram/hdrhistogram-go"
 )
 
 var (

--- a/pkg/targets/timescaledb/file_data_source.go
+++ b/pkg/targets/timescaledb/file_data_source.go
@@ -20,7 +20,6 @@ type fileDataSource struct {
 	headers *common.GeneratedDataHeaders
 }
 
-
 func (d *fileDataSource) Headers() *common.GeneratedDataHeaders {
 	// headers are read from the input file, and should be read first
 	if d.headers != nil {


### PR DESCRIPTION
The following PR adds a Makefile which simplifies the test and build process of binaries. You can build:
- specific ones, example: `make tsbs_load`
- by group ( generators, runners, loaders ), example: `make loaders` 
- all binaries `make all`.

It also simplifies testing. 
To run all tests:
```
make test
```

Apart from it, it also ensure that the proper go fmt is maintained ( via `make checkfmt` rule ). You can go fmt via `make fmt`