### PR TITLE
Add the --analyze option for tsbs_load_timescaledb

### DIFF
--- a/cmd/tsbs_load_timescaledb/main.go
+++ b/cmd/tsbs_load_timescaledb/main.go
@@ -53,6 +53,7 @@ func initProgramOptions() (*timescaledb.LoadingOptions, load.BenchmarkRunner, *l
 	opts.PartitionIndex = viper.GetBool("partition-index")
 	opts.FieldIndex = viper.GetString("field-index")
 	opts.FieldIndexCount = viper.GetInt("field-index-count")
+	opts.Analyze = viper.GetBool("analyze")
 
 	opts.ProfileFile = viper.GetString("write-profile")
 	opts.ReplicationStatsFile = viper.GetString("write-replication-stats")

--- a/load/loader-no-flow-control.go
+++ b/load/loader-no-flow-control.go
@@ -12,7 +12,7 @@ type noFlowBenchmarkRunner struct {
 }
 
 func (l *noFlowBenchmarkRunner) RunBenchmark(b targets.Benchmark) {
-	wg, start := l.preRun(b)
+	wg, start, cleanupFn := l.preRun(b)
 
 	var numChannels uint
 	if l.HashWorkers {
@@ -31,7 +31,7 @@ func (l *noFlowBenchmarkRunner) RunBenchmark(b targets.Benchmark) {
 	for _, c := range channels {
 		close(c)
 	}
-	l.postRun(wg, start)
+	l.postRun(wg, start, cleanupFn)
 }
 
 // createChannels create channels from which workers would receive tasks

--- a/pkg/targets/creator.go
+++ b/pkg/targets/creator.go
@@ -16,8 +16,8 @@ type DBCreator interface {
 	RemoveOldDB(dbName string) error
 }
 
-// DBCreatorCloser is a DBCreator that also needs a Close method to cleanup any connections
-// after the benchmark is finished.
+// DBCreatorCloser is a DBCreator that also needs a Close method to do work after the benchmark is finished
+// including closing connections or doing vacuum or analyze for a SQL table
 type DBCreatorCloser interface {
 	DBCreator
 

--- a/pkg/targets/timescaledb/benchmark.go
+++ b/pkg/targets/timescaledb/benchmark.go
@@ -61,6 +61,7 @@ func (b *benchmark) GetDBCreator() targets.DBCreator {
 		ds:      b.ds,
 		driver:  getDriver(b.opts.ForceTextFormat),
 		connStr: b.opts.GetConnectString(b.dbName),
+		tables:  make([]string, 0, 10),
 	}
 }
 

--- a/pkg/targets/timescaledb/implemented_target.go
+++ b/pkg/targets/timescaledb/implemented_target.go
@@ -59,6 +59,7 @@ func (t *timescaleTarget) TargetSpecificFlags(flagPrefix string, flagSet *pflag.
 	flagSet.Bool(flagPrefix+"partition-index", true, "Whether to build an index on the partition key")
 	flagSet.String(flagPrefix+"field-index", ValueTimeIdx, "index types for tags (comma delimited)")
 	flagSet.Int(flagPrefix+"field-index-count", 0, "Number of indexed fields (-1 for all)")
+	flagSet.Bool(flagPrefix+"analyze", false, "Whether to do vacuum analyze after the load")
 
 	flagSet.String(flagPrefix+"write-profile", "", "File to output CPU/memory profile to")
 	flagSet.String(flagPrefix+"write-replication-stats", "", "File to output replication stats to")

--- a/pkg/targets/timescaledb/program_options.go
+++ b/pkg/targets/timescaledb/program_options.go
@@ -29,6 +29,7 @@ type LoadingOptions struct {
 	PartitionIndex     bool   `yaml:"partition-index" mapstructure:"partition-index"`
 	FieldIndex         string `yaml:"field-index" mapstructure:"field-index"`
 	FieldIndexCount    int    `yaml:"field-index-count" mapstructure:"field-index-count"`
+	Analyze            bool
 
 	ProfileFile          string `yaml:"write-profile" mapstructure:"write-profile"`
 	ReplicationStatsFile string `yaml:"write-replication-stats" mapstructure:"write-replication-stats"`


### PR DESCRIPTION
The default for the option is false and vacuum analyze is done for each table when true. Even for
insert-only workloads Postgres vacuum is useful as it sets bits in the visibility map so that secondary
index scans can really be index-only.

Note that DbCreatorCloser.Close used to be called after the load and was changed as part of the
refactoring to get called when Loader.preRun finishes (which is after create table, but before the
load is started). I assume that change was a mistake and restore the old behavior here.

Example output is below. The output from Close() is interleaved with the stats reporter output
because the stats reporter goroutine isn't stopped before process exist and a pending PR fixes that.
---
time,per. metric/s,metric total,overall metric/s,per. row/s,row total,overall row/s

Summary:
loaded 17452800 metrics in 9.803sec with 4 workers (mean rate 1780368.33 metrics/sec)
loaded 1555200 rows in 9.803sec with 4 workers (mean rate 158646.68 rows/sec)
Close: vacuum analyze tags
Close: vacuum analyze cpu
Close: vacuum analyze diskio
1610580022,1745255.84,1.745280E+07,1745255.84,155517.85,1.555200E+06,155517.85
Close: vacuum analyze nginx
Close: vacuum analyze redis
Close: vacuum analyze disk
Close: vacuum analyze kernel
Close: vacuum analyze mem
Close: vacuum analyze net
Close: vacuum analyze postgresl