### PR TITLE
Add query timeout via --max-total-duration

### DIFF
--- a/pkg/query/benchmarker_test.go
+++ b/pkg/query/benchmarker_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"golang.org/x/time/rate"
 	"io/ioutil"
+	"context"
 	"math"
 	"os"
 	"reflect"
@@ -43,8 +44,8 @@ func TestProcessorHandler(t *testing.T) {
 	var requestBurst = 0
 	var rateLimiter *rate.Limiter = rate.NewLimiter(requestRate, requestBurst)
 
-	go b.processorHandler(&wg, rateLimiter, qPool, p1, 0)
-	go b.processorHandler(&wg, rateLimiter, qPool, p2, 5)
+	go b.processorHandler(context.Background(), &wg, rateLimiter, qPool, p1, 0)
+	go b.processorHandler(context.Background(), &wg, rateLimiter, qPool, p2, 5)
 	for i := 0; i < qLimit; i++ {
 		q := qPool.Get().(*testQuery)
 		b.ch <- q
@@ -85,8 +86,8 @@ func TestProcessorHandlerPreWarm(t *testing.T) {
 	var wg sync.WaitGroup
 	qPool := &testQueryPool
 	wg.Add(2)
-	go b.processorHandler(&wg, rateLimiter, qPool, p1, 0)
-	go b.processorHandler(&wg, rateLimiter, qPool, p2, 5)
+	go b.processorHandler(context.Background(), &wg, rateLimiter, qPool, p1, 0)
+	go b.processorHandler(context.Background(), &wg, rateLimiter, qPool, p2, 5)
 	for i := 0; i < qLimit; i++ {
 		q := qPool.Get().(*testQuery)
 		b.ch <- q

--- a/pkg/query/scanner_test.go
+++ b/pkg/query/scanner_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/gob"
 	"fmt"
 	"sync"
@@ -66,7 +67,7 @@ func runScan(t *testing.T, b *bytes.Buffer, limit, numQueries uint64, pool *sync
 		wg.Done()
 	}()
 	input := bufio.NewReaderSize(bytes.NewReader(b.Bytes()), 1<<20)
-	scanner.setReader(input).scan(pool, queryChan)
+	scanner.setReader(input).scan(context.Background(), pool, queryChan)
 	close(queryChan)
 	wg.Wait()
 	if got != numQueries {


### PR DESCRIPTION
This adds a timeout for query tests via the --max-total-duration option which is the max duration for all
queries. Queries won't be started once this is exceeded but the currently running query is allowed to finish.