### PR TITLE
Add QuestDB to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ loaders: tsbs_load \
  		 tsbs_load_prometheus \
  		 tsbs_load_siridb \
  		 tsbs_load_timescaledb \
- 		 tsbs_load_victoriametrics
+ 		 tsbs_load_victoriametrics \
+ 		 tsbs_load_questdb
 
 runners: tsbs_run_queries_akumuli \
 		 tsbs_run_queries_cassandra \
@@ -36,7 +37,8 @@ runners: tsbs_run_queries_akumuli \
 		 tsbs_run_queries_siridb \
 		 tsbs_run_queries_timescaledb \
 		 tsbs_run_queries_timestream \
-		 tsbs_run_queries_victoriametrics
+		 tsbs_run_queries_victoriametrics \
+		 tsbs_run_queries_questdb
 
 test:
 	$(GOTEST) -v ./...


### PR DESCRIPTION
`tsbs_load_questdb` and `tsbs_run_queries_questdb` binaries were not generated when building tsbs with `make`