### PR TITLE
Added insert-intervals-unit for sub-second granularity

### DIFF
--- a/cmd/tsbs_load/config.go
+++ b/cmd/tsbs_load/config.go
@@ -16,19 +16,20 @@ type LoaderConfig struct {
 }
 
 type RunnerConfig struct {
-	DBName          string `yaml:"db-name" mapstructure:"db-name"`
-	BatchSize       uint   `yaml:"batch-size" mapstructure:"batch-size"`
-	Workers         uint
-	Limit           uint64
-	DoLoad          bool          `yaml:"do-load" mapstructure:"do-load"`
-	DoCreateDB      bool          `yaml:"do-create-db" mapstructure:"do-create-db"`
-	DoAbortOnExist  bool          `yaml:"do-abort-on-exist" mapstructure:"do-abort-on-exist"`
-	ReportingPeriod time.Duration `yaml:"reporting-period" mapstructure:"reporting-period"`
-	Seed            int64
-	HashWorkers     bool   `yaml:"hash-workers" mapstructure:"hash-workers"`
-	InsertIntervals string `yaml:"insert-intervals" mapstructure:"insert-intervals"`
-	FlowControl     bool   `yaml:"flow-control" mapstructure:"flow-control"`
-	ChannelCapacity uint   `yaml:"channel-capacity" mapstructure:"channel-capacity"`
+	DBName              string `yaml:"db-name" mapstructure:"db-name"`
+	BatchSize           uint   `yaml:"batch-size" mapstructure:"batch-size"`
+	Workers             uint
+	Limit               uint64
+	DoLoad              bool          `yaml:"do-load" mapstructure:"do-load"`
+	DoCreateDB          bool          `yaml:"do-create-db" mapstructure:"do-create-db"`
+	DoAbortOnExist      bool          `yaml:"do-abort-on-exist" mapstructure:"do-abort-on-exist"`
+	ReportingPeriod     time.Duration `yaml:"reporting-period" mapstructure:"reporting-period"`
+	Seed                int64
+	HashWorkers         bool   `yaml:"hash-workers" mapstructure:"hash-workers"`
+	InsertIntervals     string `yaml:"insert-intervals" mapstructure:"insert-intervals"`
+	InsertIntervalsUnit string `yaml:"insert-intervals-unit" mapstructure:"insert-intervals-unit"`
+	FlowControl         bool   `yaml:"flow-control" mapstructure:"flow-control"`
+	ChannelCapacity     uint   `yaml:"channel-capacity" mapstructure:"channel-capacity"`
 }
 
 type DataSourceConfig struct {

--- a/load/insertstrategy/sleep_regulator.go
+++ b/load/insertstrategy/sleep_regulator.go
@@ -43,12 +43,12 @@ type sleepRegulator struct {
 // numWorkers=3, string='1,2' => worker '0' at least 1 second, workers '1' and '2' at least 2 seconds between inserts
 // numWorkers=1, string='0-1' => worker '0' needs to have [0,1) seconds between inserts
 // numWorkers=3, string='1,2-4'=> worker '0' have 1 second between inserts, workers '1' and '2' have [2,4) seconds between inserts
-func NewSleepRegulator(insertIntervalString string, numWorkers int, initialRand *rand.Rand) (SleepRegulator, error) {
+func NewSleepRegulator(insertIntervalString string, unitString string, numWorkers int, initialRand *rand.Rand) (SleepRegulator, error) {
 	if numWorkers <= 0 {
 		return nil, fmt.Errorf("number of workers must be positive, can't be %d", numWorkers)
 	}
 
-	sleepTimes, err := parseInsertIntervalString(insertIntervalString, numWorkers, initialRand)
+	sleepTimes, err := parseInsertIntervalString(insertIntervalString, unitString, numWorkers, initialRand)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With the `insert-intervals`  parameter one can control how frequently a batch is inserted into the DB by a worker. If one worker should insert multiple batches per second while still being rate-limited we need sub-second `insert-intervals`  which currently isn't possible.

This PR fixes that by introducing millisecond and microsecond granularity to `insert-intervals`  via `insert-intervals-unit`. 