### PR TITLE
Fix akumuli data generation

### DIFF
--- a/pkg/targets/akumuli/implemented_target.go
+++ b/pkg/targets/akumuli/implemented_target.go
@@ -25,7 +25,7 @@ func (t *akumuliTarget) TargetName() string {
 }
 
 func (t *akumuliTarget) Serializer() serialize.PointSerializer {
-	return &Serializer{}
+	return NewAkumuliSerializer()
 }
 
 func (t *akumuliTarget) Benchmark(string, *source.DataSourceConfig, *viper.Viper) (targets.Benchmark, error) {


### PR DESCRIPTION
The data generator for akumuli crashes due to assignment to nil map, which can be simply fixed by calling the constructor to the serializer.