### PR TITLE
Bump actions/setup-go to v6.4.0 (node24)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.15
 


### PR DESCRIPTION
## Summary

- Bump `actions/setup-go` to v6.4.0 (node24)

## Context

`actions/setup-go` v5 and below use Node 20/16 which is deprecated on GitHub Actions runners. v6.x is the node24-compatible release.