### PR TITLE
Query generation panics for `cpu-max-all-*` with cratedb, questdb, akumuli, timestream

### DIFF
--- a/cmd/tsbs_generate_queries/databases/cratedb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops.go
@@ -44,8 +44,8 @@ func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 // Queries:
 // cpu-max-all-1
 // cpu-max-all-8
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 	selectClauses := d.getSelectAggClauses("max", devops.GetAllCPUMetrics())
 	hosts, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
@@ -85,7 +85,7 @@ func TestDevopsMaxAllCPUQuery(t *testing.T) {
 		)}
 
 	got := &query.CrateDB{}
-	d.MaxAllCPU(got, 2)
+	d.MaxAllCPU(got, 2, devops.MaxAllDuration)
 
 	if !reflect.DeepEqual(want.SqlQuery, got.SqlQuery) {
 		t.Errorf("incorrect sql query:\ngot: %s\n want:\n %s",

--- a/cmd/tsbs_generate_queries/databases/questdb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/questdb/devops.go
@@ -42,8 +42,8 @@ func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 // Queries:
 // cpu-max-all-1
 // cpu-max-all-8
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 	selectClauses := d.getSelectAggClauses("max", devops.GetAllCPUMetrics())
 	hosts, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/questdb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/questdb/devops_test.go
@@ -129,7 +129,7 @@ func TestMaxAllCPU(t *testing.T) {
 
 	testFunc := func(d *Devops, c testCase) query.Query {
 		q := d.GenerateEmptyQuery()
-		d.MaxAllCPU(q, c.input)
+		d.MaxAllCPU(q, c.input, devops.MaxAllDuration)
 		return q
 	}
 

--- a/cmd/tsbs_run_queries_cratedb/main.go
+++ b/cmd/tsbs_run_queries_cratedb/main.go
@@ -135,7 +135,13 @@ func (p *processor) ProcessQuery(q query.Query, isWarm bool) ([]*query.Stat, err
 	} else if p.opts.printResponse {
 		prettyPrintResponse(rows, tq)
 	}
-	defer rows.Close()
+	// Fetching all the rows to confirm that the query is fully completed.
+	for rows.Next() {
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	took := float64(time.Since(start).Nanoseconds()) / 1e6
 	stat := query.GetStat()


### PR DESCRIPTION
### Steps to reproduce

```sh
tsbs_generate_queries --format cratedb --use-case cpu-only \
  --query-type cpu-max-all-1 --scale 100 --seed 123 \
  --timestamp-start 2016-01-01T00:00:00Z --timestamp-end 2016-01-02T00:00:00Z \
  --queries 10 --file /tmp/queries
```

Panics with `unimplemented query: (*cratedb.Devops)`. Same for `--format questdb`, `akumuli`, `timestream`.


PR #168 ("Add multinode to master", 2021-06-30) changed the `MaxAllCPU` filler signature to take a `duration time.Duration` parameter and updated most query generators but missed these DBs.

This PR add support for CrateDB, QuestDB, Akumuli and Timestream to fix `cpu-max-all-*` issue